### PR TITLE
test: 增加 HttpClient 的测试接口和 OkHttpClientAdapter 的测试类

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,10 +23,9 @@ dependencies {
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "org.mockito:mockito-inline:${mockitoInlineVersion}"
 
-    testImplementation(platform("org.junit:junit-bom:${junit5Version}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testImplementation("org.assertj:assertj-core:${assertjVersion}")
-    testImplementation("com.squareup.okhttp3:mockwebserver:${okhttpVersion}")
+    testImplementation platform("org.junit:junit-bom:${junit5Version}")
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
 }
 
 test {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,6 +22,18 @@ dependencies {
 
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "org.mockito:mockito-inline:${mockitoInlineVersion}"
+
+    testImplementation(platform("org.junit:junit-bom:${junit5Version}"))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation("org.assertj:assertj-core:${assertjVersion}")
+    testImplementation("com.squareup.okhttp3:mockwebserver:${okhttpVersion}")
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 task relocateShadowJar(type: ConfigureShadowRelocation) {

--- a/core/src/main/java/com/wechat/pay/java/core/exception/MalformedMessageException.java
+++ b/core/src/main/java/com/wechat/pay/java/core/exception/MalformedMessageException.java
@@ -1,6 +1,7 @@
 package com.wechat.pay.java.core.exception;
 
-/** 当解析微信支付回调通知异常时抛出，例如回调通知参数不正确、解析通知数据失败。 */
+
+/** 解析微信支付应答或回调报文异常时抛出，例如回调通知参数不正确、应答类型错误。 */
 public class MalformedMessageException extends WechatPayException {
 
   private static final long serialVersionUID = -1049702516796430238L;

--- a/core/src/main/java/com/wechat/pay/java/core/exception/MalformedMessageException.java
+++ b/core/src/main/java/com/wechat/pay/java/core/exception/MalformedMessageException.java
@@ -1,6 +1,5 @@
 package com.wechat.pay.java.core.exception;
 
-
 /** 解析微信支付应答或回调报文异常时抛出，例如回调通知参数不正确、应答类型错误。 */
 public class MalformedMessageException extends WechatPayException {
 

--- a/core/src/main/java/com/wechat/pay/java/core/http/AbstractHttpClient.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/AbstractHttpClient.java
@@ -56,6 +56,7 @@ public abstract class AbstractHttpClient implements HttpClient {
     }
 
     if (originalResponse.getBody() != null
+        && !originalResponse.getBody().isEmpty()
         && !MediaType.APPLICATION_JSON.equals(originalResponse.getContentType())) {
       throw new MalformedMessageException(
           "Unsupported content-type[%s]\nhttpRequest[%s]",

--- a/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
@@ -29,7 +29,7 @@ public interface HttpClientTest {
     public int two;
   }
 
-  String testUrl = "/test/url?p1=a&p2=b";
+  String testUrl = "/path/to/test?p1=a&p2=b&p3=[ab%2F%23cd]";
   String testResponseBody = "{\"one\":\"one\",\"two\":2}";
 
   static Stream<Arguments> requestProvider() {
@@ -156,10 +156,7 @@ public interface HttpClientTest {
 
     final ServiceException thrown =
         assertThrows(
-            ServiceException.class,
-            () -> {
-              client.get(null, requestUrl.toString(), Response.class);
-            });
+            ServiceException.class, () -> client.get(null, requestUrl.toString(), Response.class));
     assertEquals(400, thrown.getHttpStatusCode());
     assertEquals("INVALID_REQUEST", thrown.getErrorCode());
     assertEquals("test message", thrown.getErrorMessage());
@@ -178,9 +175,7 @@ public interface HttpClientTest {
     HttpUrl requestUrl = server.url(testUrl);
     assertThrows(
         MalformedMessageException.class,
-        () -> {
-          client.get(null, requestUrl.toString(), Response.class);
-        });
+        () -> client.get(null, requestUrl.toString(), Response.class));
 
     server.shutdown();
   }
@@ -194,10 +189,7 @@ public interface HttpClientTest {
     HttpUrl requestUrl = server.url(testUrl);
 
     assertThrows(
-        ValidationException.class,
-        () -> {
-          client.get(null, requestUrl.toString(), Response.class);
-        });
+        ValidationException.class, () -> client.get(null, requestUrl.toString(), Response.class));
 
     server.shutdown();
   }
@@ -206,9 +198,6 @@ public interface HttpClientTest {
   default void testExecute_HttpException() {
     HttpClient client = createHttpClient();
     assertThrows(
-        HttpException.class,
-        () -> {
-          client.get(null, "http://url.not.avalible", Response.class);
-        });
+        HttpException.class, () -> client.get(null, "http://url.not.avalible", Response.class));
   }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
@@ -1,0 +1,154 @@
+package com.wechat.pay.java.core.http;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.wechat.pay.java.core.exception.ServiceException;
+import java.util.stream.Stream;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public interface HttpClientTest {
+  HttpClient createHttpClient();
+
+  class Response {
+    public String one;
+    public int two;
+  }
+
+  String testUrl = "/test/url?p1=a&p2=b";
+  String testResponseBody = "{\"one\":\"one\",\"two\":2}";
+
+  static Stream<Arguments> requestProvider() {
+    return Stream.of(
+        arguments(HttpMethod.GET, Named.of("无body", "")),
+        arguments(HttpMethod.DELETE, Named.of("无body", "")),
+        arguments(HttpMethod.POST, Named.of("无body", "")),
+        arguments(HttpMethod.POST, Named.of("有body", "post-data")),
+        arguments(HttpMethod.PUT, Named.of("无body", "")),
+        arguments(HttpMethod.PUT, Named.of("有body", "put-data")),
+        arguments(HttpMethod.PATCH, Named.of("无body", "")),
+        arguments(HttpMethod.PATCH, Named.of("有body", "patch-data")));
+  }
+
+  @DisplayName("测试请求参数是否正确")
+  @ParameterizedTest(name = "case {index}: {0} {1}")
+  @MethodSource("requestProvider")
+  default void testExecute_Request(HttpMethod method, String requestBody) throws Exception {
+    HttpClient client = createHttpClient();
+
+    MockWebServer server = new MockWebServer();
+    server.enqueue(
+        new MockResponse()
+            .setBody(testResponseBody)
+            .setHeader("Content-Type", "application/json; charset=utf-8"));
+    server.start();
+
+    HttpUrl requestUrl = server.url(testUrl);
+    HttpHeaders headers = new HttpHeaders();
+    headers.addHeader("Test-Header1", "HeaderValue1");
+    headers.addHeader("Test-Header2", "HeaderValue2");
+
+    HttpRequest.Builder requestBuilder =
+        new HttpRequest.Builder().httpMethod(method).url(requestUrl.url()).headers(headers);
+
+    if (method == HttpMethod.POST || method == HttpMethod.PATCH || method == HttpMethod.PUT) {
+      requestBuilder.body(new JsonRequestBody.Builder().body(requestBody).build());
+    }
+
+    client.execute(requestBuilder.build(), null);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo(method.name());
+    assertThat(request.getRequestUrl()).isEqualTo(requestUrl);
+    assertThat(request.getHeader("Test-Header1")).isEqualTo("HeaderValue1");
+    assertThat(request.getHeader("Test-Header2")).isEqualTo("HeaderValue2");
+    assertThat(request.getBody().readUtf8()).isEqualTo(requestBody);
+
+    server.shutdown();
+  }
+
+  @DisplayName("测试应答处理200是否正确")
+  @ParameterizedTest(name = "case {index}: {0} {1}")
+  @MethodSource("requestProvider")
+  default void testExecute_Response_200Ok(HttpMethod method, String requestBody) throws Exception {
+    HttpClient client = createHttpClient();
+
+    MockWebServer server = new MockWebServer();
+    server.enqueue(
+        new MockResponse()
+            .setBody(testResponseBody)
+            .setHeader("Test-Header", "HeaderValue")
+            .setHeader("Content-Type", "application/json; charset=utf-8"));
+    server.start();
+
+    HttpUrl requestUrl = server.url(testUrl);
+    HttpRequest.Builder requestBuilder =
+        new HttpRequest.Builder().httpMethod(method).url(requestUrl.url());
+
+    if (method == HttpMethod.POST || method == HttpMethod.PATCH || method == HttpMethod.PUT) {
+      requestBuilder.body(new JsonRequestBody.Builder().body(requestBody).build());
+    }
+
+    HttpResponse<Response> response = client.execute(requestBuilder.build(), Response.class);
+    assertThat(response.getServiceResponse().one).isEqualTo("one");
+    assertThat(response.getServiceResponse().two).isEqualTo(2);
+    assertThat(response.getHeaders().getHeader("Test-Header")).isEqualTo("HeaderValue");
+    JsonResponseBody responseBody = (JsonResponseBody) response.getBody();
+    assertThat(responseBody.getBody()).isEqualTo(testResponseBody);
+  }
+
+  @DisplayName("测试应答处理204是否正确")
+  @ParameterizedTest(name = "case {index}: {0} {1}")
+  @MethodSource("requestProvider")
+  default void testExecute_Response_204NoContent(HttpMethod method, String requestBody)
+      throws Exception {
+    HttpClient client = createHttpClient();
+
+    MockWebServer server = new MockWebServer();
+    server.enqueue(
+        new MockResponse()
+            .setStatus("HTTP/1.1 204 No Content")
+            .setHeader("Test-Header", "HeaderValue"));
+    server.start();
+
+    HttpUrl requestUrl = server.url(testUrl);
+    HttpRequest.Builder requestBuilder =
+        new HttpRequest.Builder().httpMethod(method).url(requestUrl.url());
+
+    if (method == HttpMethod.POST || method == HttpMethod.PATCH || method == HttpMethod.PUT) {
+      requestBuilder.body(new JsonRequestBody.Builder().body(requestBody).build());
+    }
+
+    client.execute(requestBuilder.build(), Response.class);
+    // todo: need an download() API which would not check response's Content-Type
+  }
+
+  @Test
+  default void testExecute_Response_400() throws Exception {
+    HttpClient client = createHttpClient();
+    MockWebServer server = new MockWebServer();
+    server.enqueue(
+        new MockResponse()
+            .setStatus("HTTP/1.1 400 Bad Request")
+            .setBody("{\"code\":\"INVALID_REQUEST\",\"message\":\"test message\"}")
+            .setHeader("Content-Type", "application/json; charset=utf-8"));
+    server.start();
+    HttpUrl requestUrl = server.url(testUrl);
+
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(
+            () -> {
+              HttpResponse<Response> response =
+                  client.get(null, requestUrl.toString(), Response.class);
+            });
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
@@ -6,9 +6,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import com.wechat.pay.java.core.exception.HttpException;
 import com.wechat.pay.java.core.exception.MalformedMessageException;
 import com.wechat.pay.java.core.exception.ServiceException;
-import java.util.stream.Stream;
-
 import com.wechat.pay.java.core.exception.ValidationException;
+import java.util.stream.Stream;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -22,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public interface HttpClientTest {
   HttpClient createHttpClient();
+
   HttpClient createFalseValidationHttpClient();
 
   class Response {
@@ -154,10 +154,12 @@ public interface HttpClientTest {
     server.start();
     HttpUrl requestUrl = server.url(testUrl);
 
-    final ServiceException thrown = assertThrows(
+    final ServiceException thrown =
+        assertThrows(
             ServiceException.class,
-            () -> { client.get(null, requestUrl.toString(), Response.class); }
-    );
+            () -> {
+              client.get(null, requestUrl.toString(), Response.class);
+            });
     assertEquals(400, thrown.getHttpStatusCode());
     assertEquals("INVALID_REQUEST", thrown.getErrorCode());
     assertEquals("test message", thrown.getErrorMessage());
@@ -169,15 +171,16 @@ public interface HttpClientTest {
     HttpClient client = createHttpClient();
     MockWebServer server = new MockWebServer();
     server.enqueue(
-            new MockResponse()
-                    .setBody("testResponseBody")
-                    .setHeader("Content-Type", "text/plain; charset=utf-8"));
+        new MockResponse()
+            .setBody("testResponseBody")
+            .setHeader("Content-Type", "text/plain; charset=utf-8"));
     server.start();
     HttpUrl requestUrl = server.url(testUrl);
     assertThrows(
-            MalformedMessageException.class,
-            () -> { client.get(null, requestUrl.toString(), Response.class); }
-    );
+        MalformedMessageException.class,
+        () -> {
+          client.get(null, requestUrl.toString(), Response.class);
+        });
 
     server.shutdown();
   }
@@ -191,9 +194,10 @@ public interface HttpClientTest {
     HttpUrl requestUrl = server.url(testUrl);
 
     assertThrows(
-            ValidationException.class,
-            () -> { client.get(null, requestUrl.toString(), Response.class); }
-    );
+        ValidationException.class,
+        () -> {
+          client.get(null, requestUrl.toString(), Response.class);
+        });
 
     server.shutdown();
   }
@@ -202,8 +206,9 @@ public interface HttpClientTest {
   default void testExecute_HttpException() {
     HttpClient client = createHttpClient();
     assertThrows(
-            HttpException.class,
-            () -> { client.get(null, "http://url.not.avalible", Response.class); }
-    );
+        HttpException.class,
+        () -> {
+          client.get(null, "http://url.not.avalible", Response.class);
+        });
   }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterV2Test.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterV2Test.java
@@ -35,4 +35,35 @@ public class OkHttpClientAdapterV2Test implements HttpClientTest {
 
     return new DefaultHttpClientBuilder().credential(credential).validator(validator).build();
   }
+
+    @Override
+    public HttpClient createFalseValidationHttpClient() {
+        Credential credential =
+                new Credential() {
+                    @Override
+                    public String getSchema() {
+                        return "foo";
+                    }
+
+                    @Override
+                    public String getMerchantId() {
+                        return "1234567890";
+                    }
+
+                    @Override
+                    public String getAuthorization(URI uri, String httpMethod, String signBody) {
+                        return "bar";
+                    }
+                };
+
+        Validator validator =
+                new Validator() {
+                    @Override
+                    public <T> boolean validate(HttpHeaders responseHeaders, String body) {
+                        return false;
+                    }
+                };
+
+        return new DefaultHttpClientBuilder().credential(credential).validator(validator).build();
+    }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterV2Test.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterV2Test.java
@@ -1,0 +1,38 @@
+package com.wechat.pay.java.core.http;
+
+import com.wechat.pay.java.core.auth.Credential;
+import com.wechat.pay.java.core.auth.Validator;
+import java.net.URI;
+
+public class OkHttpClientAdapterV2Test implements HttpClientTest {
+  @Override
+  public HttpClient createHttpClient() {
+    Credential credential =
+        new Credential() {
+          @Override
+          public String getSchema() {
+            return "foo";
+          }
+
+          @Override
+          public String getMerchantId() {
+            return "1234567890";
+          }
+
+          @Override
+          public String getAuthorization(URI uri, String httpMethod, String signBody) {
+            return "bar";
+          }
+        };
+
+    Validator validator =
+        new Validator() {
+          @Override
+          public <T> boolean validate(HttpHeaders responseHeaders, String body) {
+            return true;
+          }
+        };
+
+    return new DefaultHttpClientBuilder().credential(credential).validator(validator).build();
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterV2Test.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterV2Test.java
@@ -36,34 +36,34 @@ public class OkHttpClientAdapterV2Test implements HttpClientTest {
     return new DefaultHttpClientBuilder().credential(credential).validator(validator).build();
   }
 
-    @Override
-    public HttpClient createFalseValidationHttpClient() {
-        Credential credential =
-                new Credential() {
-                    @Override
-                    public String getSchema() {
-                        return "foo";
-                    }
+  @Override
+  public HttpClient createFalseValidationHttpClient() {
+    Credential credential =
+        new Credential() {
+          @Override
+          public String getSchema() {
+            return "foo";
+          }
 
-                    @Override
-                    public String getMerchantId() {
-                        return "1234567890";
-                    }
+          @Override
+          public String getMerchantId() {
+            return "1234567890";
+          }
 
-                    @Override
-                    public String getAuthorization(URI uri, String httpMethod, String signBody) {
-                        return "bar";
-                    }
-                };
+          @Override
+          public String getAuthorization(URI uri, String httpMethod, String signBody) {
+            return "bar";
+          }
+        };
 
-        Validator validator =
-                new Validator() {
-                    @Override
-                    public <T> boolean validate(HttpHeaders responseHeaders, String body) {
-                        return false;
-                    }
-                };
+    Validator validator =
+        new Validator() {
+          @Override
+          public <T> boolean validate(HttpHeaders responseHeaders, String body) {
+            return false;
+          }
+        };
 
-        return new DefaultHttpClientBuilder().credential(credential).validator(validator).build();
-    }
+    return new DefaultHttpClientBuilder().credential(credential).validator(validator).build();
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,9 @@
 slf4jVersion=1.7.36
 junitVersion=4.13.2
+junit5Version=5.8.2
 okhttpVersion=4.10.0
 gsonVersion=2.9.0
 mockitoInlineVersion=4.6.1
+assertjVersion=3.23.1
 spotlessVersion=6.8.0
 shadowVersion=7.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,5 @@ junit5Version=5.8.2
 okhttpVersion=4.10.0
 gsonVersion=2.9.0
 mockitoInlineVersion=4.6.1
-assertjVersion=3.23.1
 spotlessVersion=6.8.0
 shadowVersion=7.1.2


### PR DESCRIPTION
# 背景

不同的 HttpClient 实现之间测试用例难以复用，测试成本高

# 实现思路

使用了 junit5 的 [Test Interfaces and Default Methods](https://junit.org/junit5/docs/current/user-guide/#writing-tests-test-interfaces-and-default-methods)，配合 mockwebserver 对以下用例进行了测试：

+ get/post/put/patch/delete 请求参数是否正确
+ get/post/put/patch/delete 应答处理200是否正确
+ get/post/put/patch/delete 应答处理204是否正确
+ `ServiceException`、`MalformedMessageException`、`ValidationException` 和 `HttpException` 的典型情况
