### PR TITLE
refactor: 基于JCA重写了cipher，以便于后续使用的密码算法库

### DIFF
--- a/buildSrc/src/main/groovy/common.gradle
+++ b/buildSrc/src/main/groovy/common.gradle
@@ -19,7 +19,7 @@ repositories {
 spotless {
     java {
         removeUnusedImports()
-        googleJavaFormat()
+        googleJavaFormat('1.7')
     }
 }
 

--- a/core/src/main/java/com/wechat/pay/java/core/certificate/CertificateProvider.java
+++ b/core/src/main/java/com/wechat/pay/java/core/certificate/CertificateProvider.java
@@ -10,4 +10,11 @@ public interface CertificateProvider {
    * @return X.509证书实例
    */
   X509Certificate getCertificate(String serialNumber);
+
+  /**
+   * 获取最新可用的微信支付平台证书
+   *
+   * @return X.509证书实例
+   */
+  X509Certificate getAvailableCertificate();
 }

--- a/core/src/main/java/com/wechat/pay/java/core/certificate/InMemoryCertificateProvider.java
+++ b/core/src/main/java/com/wechat/pay/java/core/certificate/InMemoryCertificateProvider.java
@@ -11,19 +11,40 @@ public final class InMemoryCertificateProvider implements CertificateProvider {
 
   private final ConcurrentHashMap<BigInteger, X509Certificate> certificates =
       new ConcurrentHashMap<>();
+  private final X509Certificate availableCertificate;
 
-  public InMemoryCertificateProvider(List<X509Certificate> listCertificate) {
-    if (listCertificate.isEmpty()) {
+  public InMemoryCertificateProvider(List<X509Certificate> certificates) {
+    if (certificates.isEmpty()) {
       throw new IllegalArgumentException("The parameter list of constructor is empty.");
     }
-    for (X509Certificate item : listCertificate) {
-      certificates.put(item.getSerialNumber(), item);
+    // 假设拿到的都是可用的，选取一个能用最久的
+    X509Certificate longest = null;
+    for (X509Certificate item : certificates) {
+      this.certificates.put(item.getSerialNumber(), item);
+      if (longest == null || item.getNotAfter().after(longest.getNotAfter())) {
+        longest = item;
+      }
     }
+    availableCertificate = longest;
   }
 
+  /**
+   * @param serialNumber 微信支付平台证书序列号
+   * @return X.509证书实例
+   */
   @Override
   public X509Certificate getCertificate(String serialNumber) {
     BigInteger key = new BigInteger(serialNumber, Constant.HEX);
     return certificates.get(key);
+  }
+
+  /**
+   * 获取最新可用的微信支付平台证书
+   *
+   * @return X.509证书实例
+   */
+  @Override
+  public X509Certificate getAvailableCertificate() {
+    return availableCertificate;
   }
 }

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractAeadCipher.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractAeadCipher.java
@@ -20,7 +20,8 @@ public abstract class AbstractAeadCipher implements AeadCipher {
   private final int tagLengthBit;
   private final byte[] key;
 
-  public AbstractAeadCipher(String algorithm, String transformation, int tagLengthBit, byte[] key) {
+  protected AbstractAeadCipher(
+      String algorithm, String transformation, int tagLengthBit, byte[] key) {
     this.algorithm = algorithm;
     this.transformation = transformation;
     this.tagLengthBit = tagLengthBit;
@@ -42,15 +43,16 @@ public abstract class AbstractAeadCipher implements AeadCipher {
           javax.crypto.Cipher.ENCRYPT_MODE,
           new SecretKeySpec(key, algorithm),
           new GCMParameterSpec(tagLengthBit, nonce));
-      cipher.updateAAD(
-          associatedData == null ? "".getBytes(StandardCharsets.UTF_8) : associatedData);
+      if (associatedData != null) {
+        cipher.updateAAD(associatedData);
+      }
       return Base64.getEncoder().encodeToString(cipher.doFinal(plaintext));
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new IllegalStateException(e);
     } catch (InvalidKeyException
         | InvalidAlgorithmParameterException
         | BadPaddingException
-        | IllegalBlockSizeException e) {
+        | IllegalBlockSizeException
+        | NoSuchAlgorithmException
+        | NoSuchPaddingException e) {
       throw new IllegalArgumentException(e);
     }
   }
@@ -70,12 +72,14 @@ public abstract class AbstractAeadCipher implements AeadCipher {
           javax.crypto.Cipher.DECRYPT_MODE,
           new SecretKeySpec(key, algorithm),
           new GCMParameterSpec(tagLengthBit, nonce));
-      cipher.updateAAD(
-          associatedData == null ? "".getBytes(StandardCharsets.UTF_8) : associatedData);
+      if (associatedData != null) {
+        cipher.updateAAD(associatedData);
+      }
       return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new IllegalStateException(e);
-    } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+    } catch (InvalidKeyException
+        | InvalidAlgorithmParameterException
+        | NoSuchAlgorithmException
+        | NoSuchPaddingException e) {
       throw new IllegalArgumentException(e);
     } catch (BadPaddingException | IllegalBlockSizeException e) {
       throw new DecryptionException("Decryption failed", e);

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractAeadCipher.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractAeadCipher.java
@@ -1,0 +1,84 @@
+package com.wechat.pay.java.core.cipher;
+
+import com.wechat.pay.java.core.exception.DecryptionException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/** 带有关联数据的认证加密器 */
+public abstract class AbstractAeadCipher implements AeadCipher {
+
+  private final String algorithm;
+  private final String transformation;
+  private final int tagLengthBit;
+  private final byte[] key;
+
+  public AbstractAeadCipher(String algorithm, String transformation, int tagLengthBit, byte[] key) {
+    this.algorithm = algorithm;
+    this.transformation = transformation;
+    this.tagLengthBit = tagLengthBit;
+    this.key = key;
+  }
+
+  /**
+   * 加密并转换为字符串
+   *
+   * @param associatedData AAD，额外的认证加密数据，可以为空
+   * @param nonce IV，随机字符串初始化向量
+   * @param plaintext 明文
+   * @return Base64编码的密文
+   */
+  public String encrypt(byte[] associatedData, byte[] nonce, byte[] plaintext) {
+    try {
+      javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance(transformation);
+      cipher.init(
+          javax.crypto.Cipher.ENCRYPT_MODE,
+          new SecretKeySpec(key, algorithm),
+          new GCMParameterSpec(tagLengthBit, nonce));
+      cipher.updateAAD(
+          associatedData == null ? "".getBytes(StandardCharsets.UTF_8) : associatedData);
+      return Base64.getEncoder().encodeToString(cipher.doFinal(plaintext));
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      throw new IllegalStateException(e);
+    } catch (InvalidKeyException
+        | InvalidAlgorithmParameterException
+        | BadPaddingException
+        | IllegalBlockSizeException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
+   * 解密并转换为字符串
+   *
+   * @param associatedData AAD，额外的认证加密数据，可以为空
+   * @param nonce IV，随机字符串初始化向量
+   * @param ciphertext 密文
+   * @return UTF-8编码的明文
+   */
+  public String decrypt(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
+    try {
+      javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance(transformation);
+      cipher.init(
+          javax.crypto.Cipher.DECRYPT_MODE,
+          new SecretKeySpec(key, algorithm),
+          new GCMParameterSpec(tagLengthBit, nonce));
+      cipher.updateAAD(
+          associatedData == null ? "".getBytes(StandardCharsets.UTF_8) : associatedData);
+      return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      throw new IllegalStateException(e);
+    } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+      throw new IllegalArgumentException(e);
+    } catch (BadPaddingException | IllegalBlockSizeException e) {
+      throw new DecryptionException("Decryption failed", e);
+    }
+  }
+}

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyDecryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyDecryptor.java
@@ -1,0 +1,49 @@
+package com.wechat.pay.java.core.cipher;
+
+import static java.util.Objects.requireNonNull;
+
+import com.wechat.pay.java.core.exception.DecryptionException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.util.Base64;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+public abstract class AbstractPrivacyDecryptor implements PrivacyDecryptor {
+  private final PrivateKey privateKey;
+  private final Cipher cipher;
+
+  /**
+   * 构造敏感信息解密的抽象类
+   *
+   * @param transformation 加密使用的模式
+   * @param privateKey 加密使用的私钥
+   */
+  public AbstractPrivacyDecryptor(String transformation, PrivateKey privateKey) {
+    this.privateKey = requireNonNull(privateKey);
+    try {
+      cipher = Cipher.getInstance(transformation);
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      throw new RuntimeException(
+          "The current Java environment does not support " + transformation, e);
+    }
+  }
+
+  @Override
+  public String decrypt(String ciphertext) {
+    requireNonNull(ciphertext);
+    try {
+      cipher.init(Cipher.DECRYPT_MODE, privateKey);
+      return new String(
+          cipher.doFinal(Base64.getDecoder().decode(ciphertext)), StandardCharsets.UTF_8);
+    } catch (InvalidKeyException e) {
+      throw new IllegalArgumentException("The given private key is invalid for decryption", e);
+    } catch (BadPaddingException | IllegalBlockSizeException e) {
+      throw new DecryptionException("Decryption failed", e);
+    }
+  }
+}

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyDecryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyDecryptor.java
@@ -23,12 +23,12 @@ public abstract class AbstractPrivacyDecryptor implements PrivacyDecryptor {
    * @param transformation 加密使用的模式
    * @param privateKey 加密使用的私钥
    */
-  public AbstractPrivacyDecryptor(String transformation, PrivateKey privateKey) {
+  protected AbstractPrivacyDecryptor(String transformation, PrivateKey privateKey) {
     this.privateKey = requireNonNull(privateKey);
     try {
       cipher = Cipher.getInstance(transformation);
     } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new RuntimeException(
+      throw new IllegalArgumentException(
           "The current Java environment does not support " + transformation, e);
     }
   }

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyEncryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyEncryptor.java
@@ -1,0 +1,50 @@
+package com.wechat.pay.java.core.cipher;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.util.Base64;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+public abstract class AbstractPrivacyEncryptor implements PrivacyEncryptor {
+  private final PublicKey publicKey;
+  private final Cipher cipher;
+  private final String wechatPaySerial;
+
+  public AbstractPrivacyEncryptor(
+      String transformation, PublicKey publicKey, String wechatPaySerial) {
+    this.publicKey = requireNonNull(publicKey);
+    this.wechatPaySerial = requireNonNull(wechatPaySerial);
+    try {
+      cipher = Cipher.getInstance(transformation);
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      throw new RuntimeException(
+          "The current Java environment does not support " + transformation, e);
+    }
+  }
+
+  @Override
+  public String encrypt(String plaintext) {
+    requireNonNull(plaintext);
+    try {
+      cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+      return Base64.getEncoder()
+          .encodeToString(cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8)));
+    } catch (InvalidKeyException e) {
+      throw new IllegalArgumentException("RSA encryption using an illegal publicKey", e);
+    } catch (BadPaddingException | IllegalBlockSizeException e) {
+      throw new IllegalArgumentException("Plaintext is too long", e);
+    }
+  }
+
+  @Override
+  public String getWechatpaySerial() {
+    return wechatPaySerial;
+  }
+}

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyEncryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractPrivacyEncryptor.java
@@ -17,14 +17,14 @@ public abstract class AbstractPrivacyEncryptor implements PrivacyEncryptor {
   private final Cipher cipher;
   private final String wechatPaySerial;
 
-  public AbstractPrivacyEncryptor(
+  protected AbstractPrivacyEncryptor(
       String transformation, PublicKey publicKey, String wechatPaySerial) {
     this.publicKey = requireNonNull(publicKey);
     this.wechatPaySerial = requireNonNull(wechatPaySerial);
     try {
       cipher = Cipher.getInstance(transformation);
     } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new RuntimeException(
+      throw new IllegalArgumentException(
           "The current Java environment does not support " + transformation, e);
     }
   }

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractSigner.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractSigner.java
@@ -22,7 +22,7 @@ public abstract class AbstractSigner implements Signer {
    * @param certificateSerialNumber 商户API证书序列号
    * @param privateKey 商户API私钥
    */
-  public AbstractSigner(
+  protected AbstractSigner(
       String algorithm,
       String algorithmName,
       String certificateSerialNumber,

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractVerifier.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AbstractVerifier.java
@@ -24,7 +24,7 @@ public abstract class AbstractVerifier implements Verifier {
    * @param algorithmName 获取Signature对象时指定的算法，例如SHA256withRSA
    * @param certificateProvider 验签使用的微信支付平台证书管理器，非空
    */
-  public AbstractVerifier(String algorithmName, CertificateProvider certificateProvider) {
+  protected AbstractVerifier(String algorithmName, CertificateProvider certificateProvider) {
     this.certificateProvider = requireNonNull(certificateProvider);
     this.algorithmName = requireNonNull(algorithmName);
   }

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AeadAesCipher.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AeadAesCipher.java
@@ -1,7 +1,7 @@
 package com.wechat.pay.java.core.cipher;
 
 /** 带有关联数据的AES认证加解密器 */
-public final class AeadAesCipher extends AeadCipher {
+public final class AeadAesCipher extends AbstractAeadCipher {
 
   private static final String TRANSFORMATION = "AES/GCM/NoPadding";
 

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/AeadCipher.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/AeadCipher.java
@@ -1,31 +1,6 @@
 package com.wechat.pay.java.core.cipher;
 
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
-
-/** 带有关联数据的认证加密器 */
-public abstract class AeadCipher {
-
-  private final String algorithm;
-  private final String transformation;
-  private final int tagLengthBit;
-  private final byte[] key;
-
-  public AeadCipher(String algorithm, String transformation, int tagLengthBit, byte[] key) {
-    this.algorithm = algorithm;
-    this.transformation = transformation;
-    this.tagLengthBit = tagLengthBit;
-    this.key = key;
-  }
-
+public interface AeadCipher {
   /**
    * 加密并转换为字符串
    *
@@ -34,25 +9,7 @@ public abstract class AeadCipher {
    * @param plaintext 明文
    * @return Base64编码的密文
    */
-  public String encryptToString(byte[] associatedData, byte[] nonce, byte[] plaintext) {
-    try {
-      javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance(transformation);
-      cipher.init(
-          javax.crypto.Cipher.ENCRYPT_MODE,
-          new SecretKeySpec(key, algorithm),
-          new GCMParameterSpec(tagLengthBit, nonce));
-      cipher.updateAAD(
-          associatedData == null ? "".getBytes(StandardCharsets.UTF_8) : associatedData);
-      return Base64.getEncoder().encodeToString(cipher.doFinal(plaintext));
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new IllegalStateException(e);
-    } catch (InvalidKeyException
-        | InvalidAlgorithmParameterException
-        | BadPaddingException
-        | IllegalBlockSizeException e) {
-      throw new IllegalArgumentException(e);
-    }
-  }
+  String encrypt(byte[] associatedData, byte[] nonce, byte[] plaintext);
 
   /**
    * 解密并转换为字符串
@@ -62,23 +19,5 @@ public abstract class AeadCipher {
    * @param ciphertext 密文
    * @return UTF-8编码的明文
    */
-  public String decryptToString(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
-    try {
-      javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance(transformation);
-      cipher.init(
-          javax.crypto.Cipher.DECRYPT_MODE,
-          new SecretKeySpec(key, algorithm),
-          new GCMParameterSpec(tagLengthBit, nonce));
-      cipher.updateAAD(
-          associatedData == null ? "".getBytes(StandardCharsets.UTF_8) : associatedData);
-      return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new IllegalStateException(e);
-    } catch (InvalidKeyException
-        | InvalidAlgorithmParameterException
-        | BadPaddingException
-        | IllegalBlockSizeException e) {
-      throw new IllegalArgumentException(e);
-    }
-  }
+  String decrypt(byte[] associatedData, byte[] nonce, byte[] ciphertext);
 }

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15Decryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15Decryptor.java
@@ -1,0 +1,11 @@
+package com.wechat.pay.java.core.cipher;
+
+import java.security.PrivateKey;
+
+/** RSA-Pkcs1v15敏感信息解密器 */
+public final class RSAPkcs1v15Decryptor extends AbstractPrivacyDecryptor {
+
+  public RSAPkcs1v15Decryptor(PrivateKey privateKey) {
+    super("RSA/ECB/PKCS1Padding", privateKey);
+  }
+}

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15Encryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15Encryptor.java
@@ -1,0 +1,11 @@
+package com.wechat.pay.java.core.cipher;
+
+import java.security.PublicKey;
+
+/** RSA-Pkcs1v15 敏感信息加密器 */
+public final class RSAPkcs1v15Encryptor extends AbstractPrivacyEncryptor {
+
+  public RSAPkcs1v15Encryptor(PublicKey publicKey, String wechatpaySerialNumber) {
+    super("RSA/ECB/PKCS1Padding", publicKey, wechatpaySerialNumber);
+  }
+}

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPrivacyDecryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPrivacyDecryptor.java
@@ -5,9 +5,7 @@ import java.security.PrivateKey;
 /** RSA敏感信息解密器 */
 public final class RSAPrivacyDecryptor extends AbstractPrivacyDecryptor {
 
-  /**
-   * @param privateKey 应答的敏感信息解密时使用的商户私钥
-   */
+  /** @param privateKey 应答的敏感信息解密时使用的商户私钥 */
   public RSAPrivacyDecryptor(PrivateKey privateKey) {
     super("RSA/ECB/OAEPWithSHA-1AndMGF1Padding", privateKey);
   }

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPrivacyDecryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPrivacyDecryptor.java
@@ -1,62 +1,14 @@
 package com.wechat.pay.java.core.cipher;
 
-import static java.util.Objects.requireNonNull;
-
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.util.Base64;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
 
 /** RSA敏感信息解密器 */
-public final class RSAPrivacyDecryptor implements PrivacyDecryptor {
+public final class RSAPrivacyDecryptor extends AbstractPrivacyDecryptor {
 
-  private static final String RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING =
-      "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
-  private final PrivateKey privateKey;
-  private final Cipher cipher;
-
+  /**
+   * @param privateKey 应答的敏感信息解密时使用的商户私钥
+   */
   public RSAPrivacyDecryptor(PrivateKey privateKey) {
-    this.privateKey = requireNonNull(privateKey);
-    try {
-      this.cipher = Cipher.getInstance(RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING);
-      this.cipher.init(Cipher.DECRYPT_MODE, privateKey);
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new IllegalStateException(
-          "The current Java environment does not support RSA v1.5/OAEP.", e);
-    } catch (InvalidKeyException e) {
-      throw new IllegalArgumentException("RSA encryption using an illegal certificate.", e);
-    }
-  }
-
-  @Override
-  public String decrypt(String ciphertext) {
-    return decryptWithTransformation(RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING, ciphertext);
-  }
-
-  public String decryptWithTransformation(String transformation, String ciphertext) {
-    requireNonNull(ciphertext);
-    Cipher cipher = this.cipher;
-    if (!RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING.equals(transformation)) {
-      try {
-        cipher = Cipher.getInstance(transformation);
-        cipher.init(Cipher.DECRYPT_MODE, privateKey);
-      } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-        throw new IllegalStateException(
-            "The current Java environment does not support " + transformation, e);
-      } catch (InvalidKeyException e) {
-        throw new IllegalArgumentException("RSA encryption using an illegal certificate.", e);
-      }
-    }
-    try {
-      return new String(
-          cipher.doFinal(Base64.getDecoder().decode(ciphertext)), StandardCharsets.UTF_8);
-    } catch (BadPaddingException | IllegalBlockSizeException e) {
-      throw new RuntimeException("RSA Decryption failed.", e);
-    }
+    super("RSA/ECB/OAEPWithSHA-1AndMGF1Padding", privateKey);
   }
 }

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPrivacyEncryptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/RSAPrivacyEncryptor.java
@@ -1,70 +1,15 @@
 package com.wechat.pay.java.core.cipher;
 
-import static java.util.Objects.requireNonNull;
-
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.util.Base64;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
 
 /** RSA敏感信息加密器 */
-public final class RSAPrivacyEncryptor implements PrivacyEncryptor {
+public final class RSAPrivacyEncryptor extends AbstractPrivacyEncryptor {
 
-  private static final String RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING =
-      "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
-  private final PublicKey publicKey;
-  private final Cipher cipher;
-  private final String wechatPaySerial;
-
-  public RSAPrivacyEncryptor(PublicKey publicKey, String wechatPaySerial) {
-    this.wechatPaySerial = wechatPaySerial;
-    this.publicKey = publicKey;
-    try {
-      this.cipher = Cipher.getInstance(RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING);
-      this.cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-      throw new IllegalStateException(
-          "The current Java environment does not support RSA v1.5/OAEP.", e);
-    } catch (InvalidKeyException e) {
-      throw new IllegalArgumentException("RSA encryption using an illegal certificate.", e);
-    }
-  }
-
-  @Override
-  public String encrypt(String plaintext) {
-    return encryptWithTransformation(RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING, plaintext);
-  }
-
-  public String encryptWithTransformation(String transformation, String plaintext) {
-    requireNonNull(plaintext);
-    Cipher cipher = this.cipher;
-    if (!RSA_ECB_OAEPWITHSHA1ANDMGF1PADDING.equals(transformation)) {
-      try {
-        cipher = Cipher.getInstance(transformation);
-        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-      } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-        throw new IllegalStateException(
-            "The current Java environment does not support RSA v1.5/OAEP.", e);
-      } catch (InvalidKeyException e) {
-        throw new IllegalArgumentException("RSA encryption using an illegal certificate.", e);
-      }
-    }
-    try {
-      return Base64.getEncoder()
-          .encodeToString(cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8)));
-    } catch (BadPaddingException | IllegalBlockSizeException e) {
-      throw new IllegalArgumentException(
-          "The length of the encrypted original string cannot exceed 214 bytes.");
-    }
-  }
-
-  @Override
-  public String getWechatpaySerial() {
-    return wechatPaySerial;
+  /**
+   * @param publicKey 请求的敏感信息加密时使用的微信支付公钥
+   * @param wechatpaySerialNumber 微信支付平台证书的证书序列号
+   */
+  public RSAPrivacyEncryptor(PublicKey publicKey, String wechatpaySerialNumber) {
+    super("RSA/ECB/OAEPWithSHA-1AndMGF1Padding", publicKey, wechatpaySerialNumber);
   }
 }

--- a/core/src/main/java/com/wechat/pay/java/core/exception/DecryptionException.java
+++ b/core/src/main/java/com/wechat/pay/java/core/exception/DecryptionException.java
@@ -1,0 +1,15 @@
+package com.wechat.pay.java.core.exception;
+
+import java.io.Serial;
+
+public class DecryptionException extends WechatPayException {
+  @Serial private static final long serialVersionUID = 1L;
+
+  public DecryptionException(String message) {
+    super(message);
+  }
+
+  public DecryptionException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/core/src/main/java/com/wechat/pay/java/core/exception/DecryptionException.java
+++ b/core/src/main/java/com/wechat/pay/java/core/exception/DecryptionException.java
@@ -3,10 +3,6 @@ package com.wechat.pay.java.core.exception;
 public class DecryptionException extends WechatPayException {
   private static final long serialVersionUID = 1L;
 
-  public DecryptionException(String message) {
-    super(message);
-  }
-
   public DecryptionException(String message, Throwable throwable) {
     super(message, throwable);
   }

--- a/core/src/main/java/com/wechat/pay/java/core/exception/DecryptionException.java
+++ b/core/src/main/java/com/wechat/pay/java/core/exception/DecryptionException.java
@@ -1,9 +1,7 @@
 package com.wechat.pay.java.core.exception;
 
-import java.io.Serial;
-
 public class DecryptionException extends WechatPayException {
-  @Serial private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
   public DecryptionException(String message) {
     super(message);

--- a/core/src/main/java/com/wechat/pay/java/core/notification/NotificationParser.java
+++ b/core/src/main/java/com/wechat/pay/java/core/notification/NotificationParser.java
@@ -151,7 +151,7 @@ public class NotificationParser {
       throw new MalformedMessageException(
           "Parse WechatPay notification,There is no AeadCipher corresponding to the algorithm.");
     }
-    return aeadCipher.decryptToString(
+    return aeadCipher.decrypt(
         associatedData.getBytes(StandardCharsets.UTF_8),
         nonce.getBytes(StandardCharsets.UTF_8),
         Base64.getDecoder().decode(ciphertext));

--- a/core/src/main/java/com/wechat/pay/java/core/notification/RSANotificationConfig.java
+++ b/core/src/main/java/com/wechat/pay/java/core/notification/RSANotificationConfig.java
@@ -4,10 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.wechat.pay.java.core.certificate.CertificateProvider;
 import com.wechat.pay.java.core.certificate.InMemoryCertificateProvider;
-import com.wechat.pay.java.core.cipher.AeadAesCipher;
-import com.wechat.pay.java.core.cipher.AeadCipher;
-import com.wechat.pay.java.core.cipher.RSAVerifier;
-import com.wechat.pay.java.core.cipher.Verifier;
+import com.wechat.pay.java.core.cipher.*;
 import com.wechat.pay.java.core.util.PemUtil;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;

--- a/core/src/test/java/com/wechat/pay/java/core/certificate/InMemoryCertificateProviderTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/certificate/InMemoryCertificateProviderTest.java
@@ -25,4 +25,10 @@ public class InMemoryCertificateProviderTest {
     Certificate noExistsCertificate = provider.getCertificate(MERCHANT_CERTIFICATE_SERIAL_NUMBER);
     assertNull(noExistsCertificate);
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFailWithEmptyList() {
+    Vector<X509Certificate> listCertificates = new Vector<>();
+    new InMemoryCertificateProvider(listCertificates);
+  }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/cipher/AeadAesCipherTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/cipher/AeadAesCipherTest.java
@@ -2,6 +2,7 @@ package com.wechat.pay.java.core.cipher;
 
 import static com.wechat.pay.java.core.model.TestConfig.API_V3_KEY;
 
+import com.wechat.pay.java.core.exception.DecryptionException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.Assert;
@@ -24,7 +25,7 @@ public class AeadAesCipherTest {
   @Test
   public void testEncryptToString() {
     String ciphertext =
-        aeadAesCipher.encryptToString(
+        aeadAesCipher.encrypt(
             ASSOCIATED_DATA.getBytes(StandardCharsets.UTF_8),
             NONCE.getBytes(StandardCharsets.UTF_8),
             MESSAGE.getBytes(StandardCharsets.UTF_8));
@@ -34,10 +35,34 @@ public class AeadAesCipherTest {
   @Test
   public void testDecryptToString() {
     String plaintext =
-        aeadAesCipher.decryptToString(
+        aeadAesCipher.decrypt(
             ASSOCIATED_DATA.getBytes(StandardCharsets.UTF_8),
             NONCE.getBytes(StandardCharsets.UTF_8),
             Base64.getDecoder().decode(CIPHERTEXT));
     Assert.assertEquals(plaintext, MESSAGE);
+  }
+
+  @Test(expected = DecryptionException.class)
+  public void testDecryptBadAAD() {
+    aeadAesCipher.decrypt(
+        "bad-associatedData".getBytes(StandardCharsets.UTF_8),
+        NONCE.getBytes(StandardCharsets.UTF_8),
+        Base64.getDecoder().decode(CIPHERTEXT));
+  }
+
+  @Test(expected = DecryptionException.class)
+  public void testDecryptBadNonce() {
+    aeadAesCipher.decrypt(
+        ASSOCIATED_DATA.getBytes(StandardCharsets.UTF_8),
+        "bad-4a9R25RW".getBytes(StandardCharsets.UTF_8),
+        Base64.getDecoder().decode(CIPHERTEXT));
+  }
+
+  @Test(expected = DecryptionException.class)
+  public void testDecryptBadCipher() {
+    aeadAesCipher.decrypt(
+        ASSOCIATED_DATA.getBytes(StandardCharsets.UTF_8),
+        NONCE.getBytes(StandardCharsets.UTF_8),
+        new byte[128]);
   }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15DecryptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15DecryptorTest.java
@@ -1,0 +1,31 @@
+package com.wechat.pay.java.core.cipher;
+
+import static com.wechat.pay.java.core.model.TestConfig.MERCHANT_PRIVATE_KEY;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.wechat.pay.java.core.exception.DecryptionException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class RSAPkcs1v15DecryptorTest {
+
+  private static RSAPkcs1v15Decryptor rsaPkcs1v15Decryptor;
+
+  @BeforeAll
+  public static void init() {
+    rsaPkcs1v15Decryptor = new RSAPkcs1v15Decryptor(MERCHANT_PRIVATE_KEY);
+  }
+
+  @Test
+  void testDecrypt() {
+    String ciphertext =
+        "ckMdMJormpuX4nBmmhiDJqFBqPsrFIi6uLQEY5s8+Dbr91q2kC29yfghp97zG/BCo6KBGp+Blh+lIPg4/WQuQiCxJ5ZkwWvxtVd1TO7UkZVpgrW9cxDGZP28Rn5pbSMqeGA4rKMROJDblb+KBSCu/Nkvejo3yxoFDasf8ehW7rrXR21eQq1SgbvO/uUR+c81I3fUr5gO+gKgV9aKn8kTgqIRTprZkUE5CE6hvk3ybqAP7gRXAJsMGpHeoxr2uuYDBOhCeXPpRG/6ypkLd52bYOWXFHdd68GWWhN3OGXpdPUwaaJafEW4vnYTMhkacyicxVH3AtWLcsOKJoylIxjFHQ==";
+    assertEquals("plaintext", rsaPkcs1v15Decryptor.decrypt(ciphertext));
+  }
+
+  @Test
+  void testDecryptFail() {
+
+    assertThrows(DecryptionException.class, () -> rsaPkcs1v15Decryptor.decrypt("MTIzNA=="));
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15EncryptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPkcs1v15EncryptorTest.java
@@ -1,0 +1,38 @@
+package com.wechat.pay.java.core.cipher;
+
+import static com.wechat.pay.java.core.model.TestConfig.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class RSAPkcs1v15EncryptorTest {
+
+  private static RSAPkcs1v15Encryptor rsaPkcs1v15Encryptor;
+  private static RSAPkcs1v15Decryptor rsaPkcs1v15Decryptor;
+
+  @BeforeAll
+  public static void init() {
+    rsaPkcs1v15Decryptor = new RSAPkcs1v15Decryptor(MERCHANT_PRIVATE_KEY);
+    rsaPkcs1v15Encryptor =
+        new RSAPkcs1v15Encryptor(
+            MERCHANT_CERTIFICATE.getPublicKey(), MERCHANT_CERTIFICATE_SERIAL_NUMBER);
+  }
+
+  @Test
+  void testEncrypt() {
+    String ciphertext = rsaPkcs1v15Encryptor.encrypt("plaintext");
+    assertEquals("plaintext", rsaPkcs1v15Decryptor.decrypt(ciphertext));
+    assertEquals(MERCHANT_CERTIFICATE_SERIAL_NUMBER, rsaPkcs1v15Encryptor.getWechatpaySerial());
+  }
+
+  @Test
+  void testEncryptFailTooLong() {
+    int leastPaddingLen = 11; // PKCS#1 adds at least 11 bytes
+    assertDoesNotThrow(
+        () -> rsaPkcs1v15Encryptor.encrypt(new String(new byte[256 - leastPaddingLen])));
+    assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> rsaPkcs1v15Encryptor.encrypt(new String(new byte[256 - leastPaddingLen + 1])));
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPrivacyDecryptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPrivacyDecryptorTest.java
@@ -2,6 +2,7 @@ package com.wechat.pay.java.core.cipher;
 
 import static com.wechat.pay.java.core.model.TestConfig.MERCHANT_PRIVATE_KEY;
 
+import com.wechat.pay.java.core.exception.DecryptionException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -15,7 +16,6 @@ public class RSAPrivacyDecryptorTest {
           + "vePUnxQWN70RZiBcqr7O7Gb0gU3l7FkvoUFSbY44HgDJetmVow3yGIV3Tcd45o2MNQ+5F1qvjIjb3/6dkGKce4/kNTYraUMO6o6kfFXl"
           + "fg+bFRIiz8hiUpbToWdu7g0R5Hq0/YIE5vw/5Ms4gbk2HIQIfOLkY8sEPjYHA==";
   private static final String PLAINTEXT = "plaintext";
-  private static final String RSA_OAEP = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
 
   @BeforeClass
   public static void init() {
@@ -28,9 +28,8 @@ public class RSAPrivacyDecryptorTest {
     Assert.assertEquals(PLAINTEXT, decryptMsg);
   }
 
-  @Test
-  public void testDecryptWithTransformation() {
-    String decryptMsg = rsaPrivacyDecryptor.decryptWithTransformation(RSA_OAEP, CIPHERTEXT);
-    Assert.assertEquals(PLAINTEXT, decryptMsg);
+  @Test(expected = DecryptionException.class)
+  public void testDecryptFail() {
+    rsaPrivacyDecryptor.decrypt("MTIzNA==");
   }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPrivacyEncryptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPrivacyEncryptorTest.java
@@ -31,6 +31,7 @@ public class RSAPrivacyEncryptorTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testEncryptTooLargePlaintext() {
-    rsaPrivacyEncryptor.encrypt(new String(new char[220]));
+    int paddingLen = 2 * 20 + 2; // OAEP adds 2 * sha1's length + 2 padding
+    rsaPrivacyEncryptor.encrypt(new String(new char[256 - paddingLen + 1]));
   }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPrivacyEncryptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/cipher/RSAPrivacyEncryptorTest.java
@@ -11,8 +11,6 @@ public class RSAPrivacyEncryptorTest {
   private static RSAPrivacyEncryptor rsaPrivacyEncryptor;
   private static RSAPrivacyDecryptor rsaPrivacyDecryptor;
   private static final String PLAINTEXT = "plaintext";
-  private static final String RSA_OAEP = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
-  private static final String RSA_PKCS1v15 = "RSA/ECB/PKCS1Padding";
 
   @BeforeClass
   public static void init() {
@@ -23,7 +21,7 @@ public class RSAPrivacyEncryptorTest {
   }
 
   @Test
-  public void testEncrypt() {
+  public void testEncryptWithOAEP() {
     String ciphertext = rsaPrivacyEncryptor.encrypt(PLAINTEXT);
     String decryptMessage = rsaPrivacyDecryptor.decrypt(ciphertext);
     Assert.assertEquals(PLAINTEXT, decryptMessage);
@@ -31,17 +29,8 @@ public class RSAPrivacyEncryptorTest {
         MERCHANT_CERTIFICATE_SERIAL_NUMBER, rsaPrivacyEncryptor.getWechatpaySerial());
   }
 
-  @Test
-  public void testEncryptWithOAEP() {
-    String ciphertext = rsaPrivacyEncryptor.encryptWithTransformation(RSA_OAEP, PLAINTEXT);
-    String decryptMessage = rsaPrivacyDecryptor.decryptWithTransformation(RSA_OAEP, ciphertext);
-    Assert.assertEquals(PLAINTEXT, decryptMessage);
-  }
-
-  @Test
-  public void testEncryptWithPKCS1v15() {
-    String ciphertext = rsaPrivacyEncryptor.encryptWithTransformation(RSA_PKCS1v15, PLAINTEXT);
-    String decryptMessage = rsaPrivacyDecryptor.decryptWithTransformation(RSA_PKCS1v15, ciphertext);
-    Assert.assertEquals(PLAINTEXT, decryptMessage);
+  @Test(expected = IllegalArgumentException.class)
+  public void testEncryptTooLargePlaintext() {
+    rsaPrivacyEncryptor.encrypt(new String(new char[220]));
   }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/notification/NotificationParserTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/notification/NotificationParserTest.java
@@ -2,7 +2,6 @@ package com.wechat.pay.java.core.notification;
 
 import static com.wechat.pay.java.core.model.TestConfig.WECHAT_PAY_CERTIFICATE_SERIAL_NUMBER;
 
-import com.wechat.pay.java.core.cipher.AbstractAeadCipher;
 import com.wechat.pay.java.core.cipher.AeadAesCipher;
 import com.wechat.pay.java.core.cipher.AeadCipher;
 import com.wechat.pay.java.core.cipher.Verifier;

--- a/core/src/test/java/com/wechat/pay/java/core/notification/NotificationParserTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/notification/NotificationParserTest.java
@@ -56,7 +56,7 @@ public class NotificationParserTest {
     verifyNonce = notification.getResource().getNonce();
 
     AeadCipher fakeAeadCipher =
-        new AbstractAeadCipher(verifyAlgorithm, TRANSFORMATION, KEY_LENGTH_BIT, KEY) {
+        new AeadCipher() {
           @Override
           public String encrypt(byte[] associatedData, byte[] nonce, byte[] plaintext) {
             return "fake-ciphertext";

--- a/core/src/test/java/com/wechat/pay/java/core/notification/NotificationParserTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/notification/NotificationParserTest.java
@@ -2,6 +2,7 @@ package com.wechat.pay.java.core.notification;
 
 import static com.wechat.pay.java.core.model.TestConfig.WECHAT_PAY_CERTIFICATE_SERIAL_NUMBER;
 
+import com.wechat.pay.java.core.cipher.AbstractAeadCipher;
 import com.wechat.pay.java.core.cipher.AeadAesCipher;
 import com.wechat.pay.java.core.cipher.AeadCipher;
 import com.wechat.pay.java.core.cipher.Verifier;
@@ -55,14 +56,14 @@ public class NotificationParserTest {
     verifyNonce = notification.getResource().getNonce();
 
     AeadCipher fakeAeadCipher =
-        new AeadCipher(verifyAlgorithm, TRANSFORMATION, KEY_LENGTH_BIT, KEY) {
+        new AbstractAeadCipher(verifyAlgorithm, TRANSFORMATION, KEY_LENGTH_BIT, KEY) {
           @Override
-          public String encryptToString(byte[] associatedData, byte[] nonce, byte[] plaintext) {
+          public String encrypt(byte[] associatedData, byte[] nonce, byte[] plaintext) {
             return "fake-ciphertext";
           }
 
           @Override
-          public String decryptToString(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
+          public String decrypt(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
             Assert.assertArrayEquals(
                 notification.getResource().getAssociatedData().getBytes(StandardCharsets.UTF_8),
                 associatedData);
@@ -194,14 +195,14 @@ public class NotificationParserTest {
     verifyAlgorithm = notification.getResource().getAlgorithm();
     verifyNonce = notification.getResource().getNonce();
     AeadCipher fakeAeadCipher =
-        new AeadCipher(verifyAlgorithm, TRANSFORMATION, KEY_LENGTH_BIT, KEY) {
+        new AeadCipher() {
           @Override
-          public String encryptToString(byte[] associatedData, byte[] nonce, byte[] plaintext) {
+          public String encrypt(byte[] associatedData, byte[] nonce, byte[] plaintext) {
             return "fake-ciphertext";
           }
 
           @Override
-          public String decryptToString(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
+          public String decrypt(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
             return DECRYPT_OBJECT_STRING;
           }
         };
@@ -231,14 +232,14 @@ public class NotificationParserTest {
     verifyNonce = notification.getResource().getNonce();
 
     AeadCipher fakeAeadCipher =
-        new AeadCipher(verifyAlgorithm, TRANSFORMATION, KEY_LENGTH_BIT, KEY) {
+        new AeadCipher() {
           @Override
-          public String encryptToString(byte[] associatedData, byte[] nonce, byte[] plaintext) {
+          public String encrypt(byte[] associatedData, byte[] nonce, byte[] plaintext) {
             return "fake-ciphertext";
           }
 
           @Override
-          public String decryptToString(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
+          public String decrypt(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
             return DECRYPT_OBJECT_STRING;
           }
         };

--- a/service/src/main/java/com/wechat/pay/java/service/certificate/CertificateService.java
+++ b/service/src/main/java/com/wechat/pay/java/service/certificate/CertificateService.java
@@ -113,7 +113,7 @@ public class CertificateService {
     for (Data data : dataList) {
       EncryptCertificate encryptCertificate = data.getEncryptCertificate();
       String decryptCertificate =
-          aeadCipher.decryptToString(
+          aeadCipher.decrypt(
               encryptCertificate.getAssociatedData().getBytes(StandardCharsets.UTF_8),
               encryptCertificate.getNonce().getBytes(StandardCharsets.UTF_8),
               Base64.getDecoder().decode(encryptCertificate.getCiphertext()));

--- a/service/src/test/java/com/wechat/pay/java/service/certificate/CertificateServiceTest.java
+++ b/service/src/test/java/com/wechat/pay/java/service/certificate/CertificateServiceTest.java
@@ -5,6 +5,7 @@ import static com.wechat.pay.java.core.http.Constant.REQUEST_ID;
 import com.wechat.pay.java.core.Config;
 import com.wechat.pay.java.core.auth.Credential;
 import com.wechat.pay.java.core.auth.Validator;
+import com.wechat.pay.java.core.cipher.AbstractAeadCipher;
 import com.wechat.pay.java.core.cipher.AeadCipher;
 import com.wechat.pay.java.core.cipher.PrivacyDecryptor;
 import com.wechat.pay.java.core.cipher.PrivacyEncryptor;
@@ -143,19 +144,18 @@ public class CertificateServiceTest {
     String algorithm = "fake-algorithm";
     String transformation = "fake-transformation";
     int keyLengthBit = 24;
-    int tagLengthBit = 1;
     byte[] key = "key".getBytes(StandardCharsets.UTF_8);
     String mockWechatPayCertificatePath = RESOURCES_DIR + "/certificate/wechat_pay_certificate.pem";
 
     AeadCipher fakeAeadCipher =
-        new AeadCipher(algorithm, transformation, keyLengthBit, key) {
+        new AbstractAeadCipher(algorithm, transformation, keyLengthBit, key) {
           @Override
-          public String encryptToString(byte[] associatedData, byte[] nonce, byte[] plaintext) {
+          public String encrypt(byte[] associatedData, byte[] nonce, byte[] plaintext) {
             return "fake-ciphertext";
           }
 
           @Override
-          public String decryptToString(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
+          public String decrypt(byte[] associatedData, byte[] nonce, byte[] ciphertext) {
             try {
               return IOUtil.loadStringFromPath(mockWechatPayCertificatePath);
             } catch (IOException e) {


### PR DESCRIPTION
很多常用密码算法库都是基于JCA的，例如 [BC](https://www.bouncycastle.org/java.html)、[ACCP](https://github.com/corretto/amazon-corretto-crypto-provider)。

基于JCA重写 cipher后，使用其他密码学算法库变得方便，是国密库扩展的基础。