### PR TITLE
增加敏感信息加解密器

### DIFF
--- a/core/src/main/java/com/wechat/pay/java/core/annotation/Encryption.java
+++ b/core/src/main/java/com/wechat/pay/java/core/annotation/Encryption.java
@@ -1,0 +1,12 @@
+package com.wechat.pay.java.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Encryption {
+  String value();
+}

--- a/core/src/main/java/com/wechat/pay/java/core/cipher/PrivacyCipher.java
+++ b/core/src/main/java/com/wechat/pay/java/core/cipher/PrivacyCipher.java
@@ -1,0 +1,87 @@
+package com.wechat.pay.java.core.cipher;
+
+import com.wechat.pay.java.core.annotation.Encryption;
+import java.lang.reflect.Field;
+
+/** 敏感信息加解密器 */
+public class PrivacyCipher {
+
+  private PrivacyCipher() {}
+  /**
+   * 获取obj中需要加密的字段，加密后设置在encryptObj
+   *
+   * @param obj 原对象
+   * @param encryptObj 原对象的深拷贝
+   * @param encryptor 加密器
+   */
+  public static void encrypt(Object obj, Object encryptObj, PrivacyEncryptor encryptor) {
+
+    for (Field field : obj.getClass().getDeclaredFields()) {
+      field.setAccessible(true);
+      Object objFieldVal;
+      Object objEncryptFieldVal;
+      try {
+        objFieldVal = field.get(obj);
+        objEncryptFieldVal = field.get(encryptObj);
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException(e);
+      }
+      // 如果值为空，跳过
+      if (objFieldVal == null || objEncryptFieldVal == null) {
+        continue;
+      }
+      // 如果是非枚举的自定义类，递归方法
+      if (!field.isEnumConstant() && field.getType().getName().startsWith("com.wechat")) {
+        encrypt(objFieldVal, objEncryptFieldVal, encryptor);
+      }
+      // 如果不是string类型或者没有加解密注解，跳过
+      if (field.getType() != String.class || !field.isAnnotationPresent(Encryption.class)) {
+        continue;
+      }
+      try {
+        // 如果是string类型，加密值并设置给encryptObj
+        field.set(encryptObj, encryptor.encrypt((String) objFieldVal));
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+  /**
+   * 获取obj中需要解密的字段，加密后设置在decryptObj
+   *
+   * @param obj 原对象
+   * @param decryptObj 原对象的深拷贝
+   * @param decryptor 解密器
+   */
+  public static void decrypt(Object obj, Object decryptObj, PrivacyDecryptor decryptor) {
+    for (Field field : obj.getClass().getDeclaredFields()) {
+      field.setAccessible(true);
+      Object objFieldVal;
+      Object objDecryptFieldVal;
+      try {
+        objFieldVal = field.get(obj);
+        objDecryptFieldVal = field.get(decryptObj);
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException(e);
+      }
+      // 如果值为空，跳过
+      if (objFieldVal == null || objDecryptFieldVal == null) {
+        continue;
+      }
+      // 如果是非枚举的自定义类，递归方法
+      if (!field.isEnumConstant() && field.getType().getName().startsWith("com.wechat")) {
+        decrypt(objFieldVal, objDecryptFieldVal, decryptor);
+      }
+      // 如果不是string类型或者没有加解密注解，跳过
+      if (field.getType() != String.class || !field.isAnnotationPresent(Encryption.class)) {
+        continue;
+      }
+      try {
+        // 如果是string类型，解密值并设置给encryptObj
+        field.set(decryptObj, decryptor.decrypt((String) objFieldVal));
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/wechat/pay/java/core/util/ObjectUtil.java
+++ b/core/src/main/java/com/wechat/pay/java/core/util/ObjectUtil.java
@@ -1,0 +1,23 @@
+package com.wechat.pay.java.core.util;
+
+import com.google.gson.Gson;
+
+/** 对象操作工具类 */
+public class ObjectUtil {
+  private ObjectUtil() {}
+
+  public static final Gson gson = new Gson();
+
+  /**
+   * 返回深拷贝
+   *
+   * @param object 拷贝目标
+   * @param tClass 拷贝目标类型类
+   * @return 深拷贝
+   * @param <T> 拷贝目标对象类型
+   */
+  public static <T> T deepCopy(Object object, Class<T> tClass) {
+    String json = gson.toJson(object);
+    return gson.fromJson(json, tClass);
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/cipher/PrivacyCipherTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/cipher/PrivacyCipherTest.java
@@ -1,0 +1,93 @@
+package com.wechat.pay.java.core.cipher;
+
+import static com.wechat.pay.java.core.util.ObjectUtil.deepCopy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.wechat.pay.java.core.model.Object1;
+import com.wechat.pay.java.core.model.Object2;
+import com.wechat.pay.java.core.model.Object3;
+import com.wechat.pay.java.core.model.ObjectType;
+import com.wechat.pay.java.core.model.TestConfig;
+import com.wechat.pay.java.core.util.ObjectUtil;
+import org.junit.jupiter.api.Test;
+
+class PrivacyCipherTest {
+  @Test
+  void testEncrypt() {
+
+    PrivacyEncryptor encryptor =
+        new PrivacyEncryptor() {
+          @Override
+          public String encrypt(String plaintext) {
+            return "fake_" + plaintext;
+          }
+
+          @Override
+          public String getWechatpaySerial() {
+            return "fake-serial";
+          }
+        };
+    Object1 object1 = new Object1();
+    object1.setObject1EncryptVal("encrypt");
+    Object1 needEncrypt = ObjectUtil.deepCopy(object1, object1.getClass());
+    PrivacyCipher.encrypt(object1, needEncrypt, encryptor);
+    assertNotEquals(object1.getObject1EncryptVal(), needEncrypt.getObject1EncryptVal());
+  }
+
+  @Test
+  void testDecrypt() {
+    PrivacyDecryptor decryptor = ciphertext -> "fake_" + ciphertext;
+    Object1 object1 = new Object1();
+    object1.setObject1EncryptVal("need_decrypt");
+    Object1 needDecrypt = deepCopy(object1, object1.getClass());
+    PrivacyCipher.decrypt(object1, needDecrypt, decryptor);
+    assertNotEquals(object1.getObject1EncryptVal(), needDecrypt.getObject1EncryptVal());
+  }
+
+  @Test
+  void testEncryptAndDecrypt() {
+    Object1 object1 = new Object1();
+    Object2 object2 = new Object2();
+    Object3 object3 = new Object3();
+    object1.setObject1EncryptVal("object1EncryptVal");
+    object1.setObject2(object2);
+    object1.setObjectType(ObjectType.OBJCET1);
+    object2.setObject2EncryptVal("object2EncryptVal");
+    object2.setObject3(object3);
+    object3.setObject3NormalVal("object3NormalVal");
+    object3.setObject3EncryptVal("object3EncryptVal");
+    Object1 needEncryptObj = deepCopy(object1, object1.getClass());
+    PrivacyEncryptor encryptor =
+        new RSAPrivacyEncryptor(
+            TestConfig.MERCHANT_CERTIFICATE.getPublicKey(),
+            TestConfig.MERCHANT_CERTIFICATE_SERIAL_NUMBER);
+
+    PrivacyCipher.encrypt(object1, needEncryptObj, encryptor);
+
+    assertEquals(
+        object3.getObject3NormalVal(),
+        needEncryptObj.getObject2().getObject3().getObject3NormalVal());
+    assertNotEquals(object1.getObject1EncryptVal(), needEncryptObj.getObject1EncryptVal());
+    assertNotEquals(
+        object2.getObject2EncryptVal(), needEncryptObj.getObject2().getObject2EncryptVal());
+    assertNotEquals(
+        object3.getObject3EncryptVal(),
+        needEncryptObj.getObject2().getObject3().getObject3EncryptVal());
+
+    PrivacyDecryptor decryptor = new RSAPrivacyDecryptor(TestConfig.MERCHANT_PRIVATE_KEY);
+    Object1 needDecryptObj = ObjectUtil.deepCopy(needEncryptObj, needEncryptObj.getClass());
+
+    PrivacyCipher.decrypt(needEncryptObj, needDecryptObj, decryptor);
+    assertEquals(
+        object3.getObject3NormalVal(),
+        needDecryptObj.getObject2().getObject3().getObject3NormalVal());
+    assertEquals(object1.getObject1EncryptVal(), needDecryptObj.getObject1EncryptVal());
+
+    assertEquals(
+        object2.getObject2EncryptVal(), needDecryptObj.getObject2().getObject2EncryptVal());
+    assertEquals(
+        object3.getObject3EncryptVal(),
+        needDecryptObj.getObject2().getObject3().getObject3EncryptVal());
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/model/Object1.java
+++ b/core/src/test/java/com/wechat/pay/java/core/model/Object1.java
@@ -1,0 +1,49 @@
+package com.wechat.pay.java.core.model;
+
+import com.wechat.pay.java.core.annotation.Encryption;
+
+public class Object1 {
+  @Encryption("EM_APIV3")
+  private String object1EncryptVal;
+
+  private Object2 object2;
+
+  public ObjectType getObjectType() {
+    return objectType;
+  }
+
+  public void setObjectType(ObjectType objectType) {
+    this.objectType = objectType;
+  }
+
+  private ObjectType objectType;
+
+  public String getObject1EncryptVal() {
+    return object1EncryptVal;
+  }
+
+  public void setObject1EncryptVal(String object1EncryptVal) {
+    this.object1EncryptVal = object1EncryptVal;
+  }
+
+  public Object2 getObject2() {
+    return object2;
+  }
+
+  public void setObject2(Object2 object2) {
+    this.object2 = object2;
+  }
+
+  @Override
+  public String toString() {
+    return "Object1{"
+        + "object1EncryptVal='"
+        + object1EncryptVal
+        + '\''
+        + ", object2="
+        + object2
+        + ", objectType="
+        + objectType
+        + '}';
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/model/Object2.java
+++ b/core/src/test/java/com/wechat/pay/java/core/model/Object2.java
@@ -1,0 +1,37 @@
+package com.wechat.pay.java.core.model;
+
+import com.wechat.pay.java.core.annotation.Encryption;
+
+public class Object2 {
+  @Encryption("EM_APIV3")
+  private String object2EncryptVal;
+
+  private Object3 object3;
+
+  public String getObject2EncryptVal() {
+    return object2EncryptVal;
+  }
+
+  public void setObject2EncryptVal(String object2EncryptVal) {
+    this.object2EncryptVal = object2EncryptVal;
+  }
+
+  public Object3 getObject3() {
+    return object3;
+  }
+
+  public void setObject3(Object3 object3) {
+    this.object3 = object3;
+  }
+
+  @Override
+  public String toString() {
+    return "Object2{"
+        + "firstRequestValOne='"
+        + object2EncryptVal
+        + '\''
+        + ", firstRequestValSecond="
+        + object3
+        + '}';
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/model/Object3.java
+++ b/core/src/test/java/com/wechat/pay/java/core/model/Object3.java
@@ -1,0 +1,38 @@
+package com.wechat.pay.java.core.model;
+
+import com.wechat.pay.java.core.annotation.Encryption;
+
+public class Object3 {
+  private String object3NormalVal;
+
+  @Encryption("EM_APIV3")
+  private String object3EncryptVal;
+
+  public String getObject3NormalVal() {
+    return object3NormalVal;
+  }
+
+  public void setObject3NormalVal(String object3NormalVal) {
+    this.object3NormalVal = object3NormalVal;
+  }
+
+  public String getObject3EncryptVal() {
+    return object3EncryptVal;
+  }
+
+  public void setObject3EncryptVal(String object3EncryptVal) {
+    this.object3EncryptVal = object3EncryptVal;
+  }
+
+  @Override
+  public String toString() {
+    return "Object3{"
+        + "object3NormalVal='"
+        + object3NormalVal
+        + '\''
+        + ", object3EncryptVal='"
+        + object3EncryptVal
+        + '\''
+        + '}';
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/model/ObjectType.java
+++ b/core/src/test/java/com/wechat/pay/java/core/model/ObjectType.java
@@ -1,0 +1,7 @@
+package com.wechat.pay.java.core.model;
+
+public enum ObjectType {
+  OBJCET1,
+  OBJCET2,
+  OBJECT3
+}

--- a/core/src/test/java/com/wechat/pay/java/core/util/ObjectUtilTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/util/ObjectUtilTest.java
@@ -1,0 +1,30 @@
+package com.wechat.pay.java.core.util;
+
+import static com.wechat.pay.java.core.util.ObjectUtil.deepCopy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.wechat.pay.java.core.model.Object1;
+import com.wechat.pay.java.core.model.Object2;
+import com.wechat.pay.java.core.model.Object3;
+import org.junit.jupiter.api.Test;
+
+class ObjectUtilTest {
+
+  @Test
+  void testDeepCopySucc() {
+    Object1 object1 = new Object1();
+    Object2 object2 = new Object2();
+    Object3 object3 = new Object3();
+    object1.setObject1EncryptVal("object1EncryptVal");
+    object1.setObject2(object2);
+    object2.setObject2EncryptVal("object2EncryptVal");
+    object2.setObject3(object3);
+    object3.setObject3NormalVal("object3NormalVal");
+    object3.setObject3EncryptVal("object3EncryptVal");
+    Object1 copy = deepCopy(object1, object1.getClass());
+    assertEquals(object1.toString(), copy.toString());
+    copy.setObject1EncryptVal("test");
+    assertNotEquals(object1.toString(), copy.toString());
+  }
+}

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -21,7 +21,7 @@ configurations {
 }
 
 dependencies {
-    implementation project(":core")
+    api project(":core")
     implementation "com.google.code.gson:gson:${gsonVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
 


### PR DESCRIPTION
# 变更
1. 增加 PrivacyCipher，提供敏感信息加密，解密方法
2. 增加对应的工具类和Test方法

# 使用
假设TestService具有test接口，TestRequest具有需要加密的敏感信息a，TestResponse具有需要解密的敏感信息b。
1. TestService构造函数支持传入PrivacyCipher 
```java
TestService(HttpClient client, PrivacyCipher cipher)
```
3. test接口加密敏感信息：
```java
// testRequest为原请求参数，encryptRequest为testRequest的拷贝对象
TestRequest encrytRequest = ObjectUtils.deepCopy(testRequest, encryptRequest);
// 加密请求中的敏感信息，后续使用encryptRequest发送请求
encrypt(testRequest, encryptRequest, encryptor);
```
4. test接口解密敏感信息：
```java
// testResponse为原返回参数，encryptResponse为testResponse的拷贝对象
TestResponse decryptResponse = ObjectUtils.deepCopy(testResponse, decryptResponse);
// 解密返回中的敏感信息，后续使用decryptResponse作为方法返回
decrypt(testResponse decryptResponse,decryptor);
```
