### PR TITLE
Update BC version to 1.72

### DIFF
--- a/shangmi-bc/build.gradle
+++ b/shangmi-bc/build.gradle
@@ -4,8 +4,8 @@ plugins{
 
 ext {
     publishedArtifactId = "wechatpay-java-shangmi-bc"
-    bcprov_version = "1.71.1"
-    bcpkix_version = "1.71.1"
+    bcprov_version = "1.72"
+    bcpkix_version = "1.72"
 }
 
 dependencies {


### PR DESCRIPTION
https://github.com/bcgit/bc-java/commit/58940b9c3e99b70f3cc43c00b9f1f6f1e87f1cc6#diff-f201c919a69378a664a3af9408747bab982751e91e59969c1b1b38f1820b9351R108

BC 1.72 修复了 SM2 Cipher 输入为空数组时死循环的问题