### PR TITLE
fix: fix NoSuchMethodError when your project depends on OkHttp3.x

### DIFF
--- a/core/src/main/java/com/wechat/pay/java/core/http/AbstractHttpClient.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/AbstractHttpClient.java
@@ -57,7 +57,7 @@ public abstract class AbstractHttpClient implements HttpClient {
 
     if (originalResponse.getBody() != null
         && !originalResponse.getBody().isEmpty()
-        && !MediaType.APPLICATION_JSON.equals(originalResponse.getContentType())) {
+        && !MediaType.APPLICATION_JSON.equalsWith(originalResponse.getContentType())) {
       throw new MalformedMessageException(
           String.format(
               "Unsupported content-type[%s]%nhttpRequest[%s]",

--- a/core/src/main/java/com/wechat/pay/java/core/http/HostName.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/HostName.java
@@ -16,7 +16,7 @@ public enum HostName {
     return value;
   }
 
-  public boolean equals(String string) {
+  public boolean equalsWith(String string) {
     requireNonNull(string);
     return string.startsWith(value);
   }

--- a/core/src/main/java/com/wechat/pay/java/core/http/MediaType.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/MediaType.java
@@ -19,7 +19,7 @@ public enum MediaType {
     return value;
   }
 
-  public boolean equals(String string) {
+  public boolean equalsWith(String string) {
     requireNonNull(string);
     return string.startsWith(value);
   }

--- a/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
@@ -79,9 +79,21 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
     return null;
   }
 
+  @SuppressWarnings("deprecation")
+  private okhttp3.RequestBody createRequestBody(String content, okhttp3.MediaType mediaType) {
+    // use an OkHttp3.x compatible method
+    // see https://github.com/wechatpay-apiv3/wechatpay-java/issues/70
+    return okhttp3.RequestBody.create(mediaType, content);
+  }
+
+  @SuppressWarnings("deprecation")
+  private okhttp3.RequestBody createRequestBody(byte[] content, okhttp3.MediaType mediaType) {
+    return okhttp3.RequestBody.create(mediaType, content);
+  }
+
   private RequestBody createOkHttpRequestBody(
       com.wechat.pay.java.core.http.RequestBody wechatPayRequestBody) {
-    return okhttp3.RequestBody.create(
+    return createRequestBody(
         ((JsonRequestBody) wechatPayRequestBody).getBody(),
         okhttp3.MediaType.parse(wechatPayRequestBody.getContentType()));
   }
@@ -90,7 +102,7 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
       com.wechat.pay.java.core.http.RequestBody wechatPayRequestBody) {
     FileRequestBody fileRequestBody = (FileRequestBody) wechatPayRequestBody;
     okhttp3.RequestBody okHttpFileBody =
-        okhttp3.RequestBody.create(
+        createRequestBody(
             fileRequestBody.getFile(), okhttp3.MediaType.parse(fileRequestBody.getContentType()));
     return new okhttp3.MultipartBody.Builder()
         .setType(MultipartBody.FORM)
@@ -102,7 +114,12 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
   private OriginalResponse assembleOriginalResponse(
       HttpRequest wechatPayRequest, Response okHttpResponse) {
     Map<String, String> responseHeaders = new ConcurrentHashMap<>();
-    okHttpResponse.headers().forEach((k) -> responseHeaders.put(k.getFirst(), k.getSecond()));
+    // use an OkHttp3.x compatible method
+    int headerSize = okHttpResponse.headers().size();
+    for (int i = 0; i < headerSize; ++i) {
+      responseHeaders.put(okHttpResponse.headers().name(i), okHttpResponse.headers().value(i));
+    }
+
     try {
       return new OriginalResponse.Builder()
           .request(wechatPayRequest)

--- a/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
@@ -126,7 +126,7 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
           .headers(responseHeaders)
           .statusCode(okHttpResponse.code())
           .contentType(
-              okHttpResponse.body().contentType() == null
+              okHttpResponse.body() == null || okHttpResponse.body().contentType() == null
                   ? null
                   : okHttpResponse.body().contentType().toString())
           .body(okHttpResponse.body().string())


### PR DESCRIPTION
很多开发者反馈 NoSuchMethodError，例如 #70 #60。

大部分原因是因为开发者使用了低版本的 Spring ( < 2.7）依赖了 okHttp 3.x。而我们在代码中使用了 okHttp 4.x 才有的 API `RequestBody.create(content, mediaType)`。

仔细阅读了 [OkHttp4 迁移指引](https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4/)，其中提到 okHttp 4.x 源代码和二进制兼容 OkHttp3。所以改为使用 OkHttp3 支持的接口即可。