### PR TITLE
RSAAutoCertificateConfig 可用于回调通知

### DIFF
--- a/core/src/main/java/com/wechat/pay/java/core/RSAAutoCertificateConfig.java
+++ b/core/src/main/java/com/wechat/pay/java/core/RSAAutoCertificateConfig.java
@@ -1,27 +1,80 @@
 package com.wechat.pay.java.core;
 
+import static com.wechat.pay.java.core.notification.Constant.AES_CIPHER_ALGORITHM;
+import static com.wechat.pay.java.core.notification.Constant.RSA_SIGN_TYPE;
 import static java.util.Objects.requireNonNull;
 
 import com.wechat.pay.java.core.certificate.CertificateProvider;
 import com.wechat.pay.java.core.certificate.RSAAutoCertificateProvider;
+import com.wechat.pay.java.core.cipher.AeadAesCipher;
+import com.wechat.pay.java.core.cipher.AeadCipher;
+import com.wechat.pay.java.core.cipher.RSAVerifier;
+import com.wechat.pay.java.core.cipher.Verifier;
 import com.wechat.pay.java.core.http.HttpClient;
+import com.wechat.pay.java.core.notification.NotificationConfig;
 import java.nio.charset.StandardCharsets;
-import java.security.PrivateKey;
 
 /** 具有自动下载平台证书能力的RSA配置类 */
-public final class RSAAutoCertificateConfig extends AbstractRSAConfig {
+public final class RSAAutoCertificateConfig extends AbstractRSAConfig
+    implements NotificationConfig {
 
-  private RSAAutoCertificateConfig(
-      String merchantId,
-      PrivateKey privateKey,
-      String merchantSerialNumber,
-      CertificateProvider certificateProvider) {
-    super(merchantId, privateKey, merchantSerialNumber, certificateProvider);
+  private final CertificateProvider certificateProvider;
+  private final AeadCipher aeadCipher;
+
+  private RSAAutoCertificateConfig(Builder builder) {
+    super(
+        builder.merchantId,
+        builder.privateKey,
+        builder.merchantSerialNumber,
+        builder.certificateProvider);
+    this.certificateProvider = builder.certificateProvider;
+    this.aeadCipher = new AeadAesCipher(builder.apiV3Key);
+  }
+
+  /**
+   * 获取签名类型
+   *
+   * @return 签名类型
+   */
+  @Override
+  public String getSignType() {
+    return RSA_SIGN_TYPE;
+  }
+
+  /**
+   * 获取认证加解密器类型
+   *
+   * @return 认证加解密器类型
+   */
+  @Override
+  public String getCipherType() {
+    return AES_CIPHER_ALGORITHM;
+  }
+
+  /**
+   * 创建验签器
+   *
+   * @return 验签器
+   */
+  @Override
+  public Verifier createVerifier() {
+    return new RSAVerifier(certificateProvider);
+  }
+
+  /**
+   * 创建认证加解密器
+   *
+   * @return 认证加解密器
+   */
+  @Override
+  public AeadCipher createAeadCipher() {
+    return aeadCipher;
   }
 
   public static class Builder extends AbstractRSAConfigBuilder<Builder> {
     protected HttpClient httpClient;
     protected byte[] apiV3Key;
+    protected CertificateProvider certificateProvider;
 
     public Builder apiV3Key(String apiV3key) {
       this.apiV3Key = apiV3key.getBytes(StandardCharsets.UTF_8);
@@ -48,8 +101,10 @@ public final class RSAAutoCertificateConfig extends AbstractRSAConfig {
       if (httpClient != null) {
         providerBuilder.httpClient(httpClient);
       }
-      return new RSAAutoCertificateConfig(
-          merchantId, privateKey, merchantSerialNumber, providerBuilder.build());
+
+      certificateProvider = providerBuilder.build();
+
+      return new RSAAutoCertificateConfig(this);
     }
   }
 }

--- a/core/src/test/java/com/wechat/pay/java/core/RSAAutoCertificateConfigTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/RSAAutoCertificateConfigTest.java
@@ -6,9 +6,10 @@ import static com.wechat.pay.java.core.model.TestConfig.MERCHANT_ID;
 import static com.wechat.pay.java.core.model.TestConfig.MERCHANT_PRIVATE_KEY;
 import static com.wechat.pay.java.core.model.TestConfig.MERCHANT_PRIVATE_KEY_PATH;
 import static com.wechat.pay.java.core.model.TestConfig.MERCHANT_PRIVATE_KEY_STRING;
+import static com.wechat.pay.java.core.notification.Constant.AES_CIPHER_ALGORITHM;
+import static com.wechat.pay.java.core.notification.Constant.RSA_SIGN_TYPE;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.wechat.pay.java.core.RSAAutoCertificateConfig.Builder;
 import com.wechat.pay.java.core.auth.Validator;
@@ -92,11 +93,16 @@ class RSAAutoCertificateConfigTest implements ConfigTest {
   @ParameterizedTest
   @MethodSource("BuilderProvider")
   void testConfigWithBuilderProvider(Builder builder) {
-    Config config = builder.build();
+    RSAAutoCertificateConfig config = builder.build();
     assertNotNull(config.createValidator());
     assertNotNull(config.createCredential());
     assertNotNull(config.createEncryptor());
     assertNotNull(config.createDecryptor());
+    assertNotNull(config.createAeadCipher());
+    assertNotNull(config.createVerifier());
+
+    assertEquals(RSA_SIGN_TYPE, config.getSignType());
+    assertEquals(AES_CIPHER_ALGORITHM, config.getCipherType());
   }
 
   static Stream<Builder> BuilderProvider() {


### PR DESCRIPTION
因为 `RSAAutoCertificateConfig` 包含了 APIv3Key，满足了回调的场景，所以干脆实现了 NotificationConfig。

对于开发者而言，理解更简单，而且也不存在重复构造 CertificateProvider 了。