### PR TITLE
fix: 移除 MultiPart/Form-Data 的 Part 中被 OkHttp 添加的 Content-Length

### DIFF
--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterTest.java
@@ -23,7 +23,6 @@ import java.nio.file.Paths;
 import java.util.zip.GZIPOutputStream;
 import okhttp3.Headers;
 import okhttp3.MediaType;
-import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClient.Builder;
 import okhttp3.Protocol;
@@ -312,15 +311,6 @@ public class OkHttpClientAdapterTest {
             .fileName(imageName)
             .file(IOUtil.toByteArray(inputStream))
             .build();
-    okhttp3.RequestBody fileBody =
-        okhttp3.RequestBody.create(
-            requestBody.getFile(), okhttp3.MediaType.parse(requestBody.getContentType()));
-    okhttp3.RequestBody multiPartBody =
-        new MultipartBody.Builder()
-            .setType(MultipartBody.FORM)
-            .addFormDataPart("meta", "meta")
-            .addFormDataPart("file", imageName, fileBody)
-            .build();
 
     Credential executeSendPostWithFileCredential =
         new Credential() {
@@ -373,8 +363,10 @@ public class OkHttpClientAdapterTest {
                   okhttp3.RequestBody okHttpRequestBody = chain.request().body();
 
                   Assert.assertNotNull(requestBody);
-                  Assert.assertEquals(
-                      multiPartBody.contentLength(), okHttpRequestBody.contentLength());
+
+                  Buffer bodyBuffer = new Buffer();
+                  okHttpRequestBody.writeTo(bodyBuffer);
+                  Assert.assertEquals(okHttpRequestBody.contentLength(), bodyBuffer.size());
                   Assert.assertEquals(executeSendPostWithFileMethod, HttpMethod.POST.name());
                   Assert.assertEquals(URL, chain.request().url().url().toString());
                   Assert.assertEquals(3, executeSendPostWithFileHeaders.size());


### PR DESCRIPTION
兼容服务端处理 MultiPart/Form-Data 时不接受Part中携带 `Content-Length` 的问题