### PR TITLE
使用双域名实现跨城容灾

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,14 +356,14 @@ SDK 使用 [OkHttp](https://square.github.io/okhttp/) 作为默认的 HTTP 客�
 
 目前支持的网络配置方法见下表。
 
-| 方法                                            | 说明                     | 默认值          | 更多信息                                                                                                                                                      |
-|-----------------------------------------------|------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `readTimeoutMs()`                             | 设置新连接的默认读超时            | 10*1000(10秒） | [OkHttpClient/Builder/readTimeout](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/read-timeout/)                             |
-| `writeTimeoutMs()`                            | 设置新连接的默认写超时            | 10*1000(10秒) | [OkHttpClient/Builder/writeTimeout](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/write-timeout/)                           |
-| `connectTimeoutMs()`                          | 设置新连接的默认连接超时           | 10*1000(10秒） | [OkHttpClient/Builder/connectTimeout](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/connect-timeout/)                       |
-| `proxy()`                                     | 设置客户端创建的连接时使用的 HTTP 代理 | 无            | [OkHttpClient/Builder/proxy](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/proxy/)                                          |
-| `disableRetryOnConnectionFailure()`           | 遇到网络问题时不重试             | 默认重试         | [OkHttpClient/Builder/retryOnConnectionFailure](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/retry-on-connection-failure/) |
-| `enableRetryMultiDomainOnConnectionFailure()` | 遇到网络问题时重试备域名           | 默认不重试        | 推荐开启，详细说明见下                                                                                                                                               |
+| 方法                                  | 说明                     | 默认值          | 更多信息                                                                                                                                                      |
+|-------------------------------------|------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `readTimeoutMs()`                   | 设置新连接的默认读超时            | 10*1000(10秒） | [OkHttpClient/Builder/readTimeout](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/read-timeout/)                             |
+| `writeTimeoutMs()`                  | 设置新连接的默认写超时            | 10*1000(10秒) | [OkHttpClient/Builder/writeTimeout](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/write-timeout/)                           |
+| `connectTimeoutMs()`                | 设置新连接的默认连接超时           | 10*1000(10秒） | [OkHttpClient/Builder/connectTimeout](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/connect-timeout/)                       |
+| `proxy()`                           | 设置客户端创建的连接时使用的 HTTP 代理 | 无            | [OkHttpClient/Builder/proxy](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/proxy/)                                          |
+| `disableRetryOnConnectionFailure()` | 遇到网络问题时不重试下一个 IP       | 默认重试         | [OkHttpClient/Builder/retryOnConnectionFailure](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/retry-on-connection-failure/) |
+| `enableRetryMultiDomain()`          | 遇到网络问题时重试备域名           | 默认不重试        | 推荐开启，详细说明见下                                                                                                                                               |
 
 下面的示例演示了如何使用 DefaultHttpClientBuilder 初始化某个具体的业务 Service。
 
@@ -392,11 +392,24 @@ OkHttp 默认会尝试主域名的多个 IP（当前为2个），再增加备域
 假设 `api.mch.weixin.qq.com` 解析得到 [ip1a, ip1b]，`api2.wechatpay.cn` 解析得到 [ip2a, ip2b]，不同的重试策略组合对应的尝试顺序为：
 
 + 默认：[ip1a, ip1b]
-+ enableMultiDomain：[ipa1, ip1b, ip2a, ip2b]
++ enableRetryMultiDomain：[ipa1, ip1b, ip2a, ip2b]
 + disableRetryOnConnectionFailure：[ip1a]
-+ disableRetryOnConnectionFailure + enableRetryMultiDomainOnConnectionFailure: [ip1a, ip2a]
++ disableRetryOnConnectionFailure + enableRetryMultiDomain: [ip1a, ip2a]
 
-我们推荐开发者使用 `disableRetryOnConnectionFailure` 和 `enableRetryMultiDomainOnConnectionFailure` 的组合，开启双域名容灾但不增加重试的总数。
+我们推荐开发者使用 `disableRetryOnConnectionFailure` 和 `enableRetryMultiDomain` 的组合，开启双域名容灾但不增加重试的总数。
+
+```java
+// 开启双域名重试，并关闭 OkHttp 默认的连接失败后重试
+HttpClient httpClient =
+    new DefaultHttpClientBuilder()
+        .config(config)
+        .disableRetryOnConnectionFailure()
+        .enableRetryMultiDomain()
+        .build();
+
+// 以JsapiService为例，使用 httpclient 初始化 service
+JsapiService service = new JsapiService.Builder().httpclient(httpClient).build();
+```
 
 ## 使用国密
 

--- a/core/src/main/java/com/wechat/pay/java/core/http/Constant.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/Constant.java
@@ -1,5 +1,8 @@
 package com.wechat.pay.java.core.http;
 
+import java.util.Arrays;
+import java.util.List;
+
 /** HTTP常量 */
 public final class Constant {
 
@@ -23,6 +26,10 @@ public final class Constant {
   public static final String USER_AGENT = "User-Agent";
   public static final String ACCEPT = "Accept";
   public static final String CONTENT_TYPE = "Content-Type";
+
+  public static final List<String> PRIMARY_API_DOMAIN =
+      Arrays.asList("api.mch.weixin.qq.com", "api.wechatpay.cn");
+  public static final String SECONDARY_API_DOMAIN = "api2.wechatpay.cn";
 
   private Constant() {}
 }

--- a/core/src/main/java/com/wechat/pay/java/core/http/Constant.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/Constant.java
@@ -1,6 +1,7 @@
 package com.wechat.pay.java.core.http;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /** HTTP常量 */
@@ -28,7 +29,7 @@ public final class Constant {
   public static final String CONTENT_TYPE = "Content-Type";
 
   public static final List<String> PRIMARY_API_DOMAIN =
-      Arrays.asList("api.mch.weixin.qq.com", "api.wechatpay.cn");
+      Collections.unmodifiableList(Arrays.asList("api.mch.weixin.qq.com", "api.wechatpay.cn"));
   public static final String SECONDARY_API_DOMAIN = "api2.wechatpay.cn";
 
   private Constant() {}

--- a/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
@@ -168,9 +168,7 @@ public class DefaultHttpClientBuilder
     if (retryMultiDomain) {
       okHttpClientBuilder.addInterceptor(multiDomainInterceptor);
     }
-    if (!retryOnConnectionFailure) {
-      okHttpClientBuilder.retryOnConnectionFailure(false);
-    }
+    okHttpClientBuilder.retryOnConnectionFailure(retryOnConnectionFailure);
     return new OkHttpClientAdapter(credential, validator, okHttpClientBuilder.build());
   }
 }

--- a/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
@@ -23,7 +23,7 @@ public class DefaultHttpClientBuilder
   private int connectTimeoutMs = -1;
   private Proxy proxy;
   private boolean retryMultiDomain = false;
-  private boolean retryOnConnectionFailure = true;
+  private Boolean retryOnConnectionFailure = null;
   private static final OkHttpMultiDomainInterceptor multiDomainInterceptor =
       new OkHttpMultiDomainInterceptor();
 
@@ -168,7 +168,9 @@ public class DefaultHttpClientBuilder
     if (retryMultiDomain) {
       okHttpClientBuilder.addInterceptor(multiDomainInterceptor);
     }
-    okHttpClientBuilder.retryOnConnectionFailure(retryOnConnectionFailure);
+    if (retryOnConnectionFailure != null && !retryOnConnectionFailure) {
+      okHttpClientBuilder.retryOnConnectionFailure(false);
+    }
     return new OkHttpClientAdapter(credential, validator, okHttpClientBuilder.build());
   }
 }

--- a/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
@@ -136,9 +136,7 @@ public class DefaultHttpClientBuilder
     return this;
   }
 
-  /**
-   * OkHttp 在网络问题时不重试
-   */
+  /** OkHttp 在网络问题时不重试 */
   public DefaultHttpClientBuilder disableRetryOnConnectionFailure() {
     this.retryOnConnectionFailure = false;
     return this;

--- a/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
@@ -22,7 +22,7 @@ public class DefaultHttpClientBuilder
   private int writeTimeoutMs = -1;
   private int connectTimeoutMs = -1;
   private Proxy proxy;
-  private boolean retryMultiDomainOnConnectionFailure = false;
+  private boolean retryMultiDomain = false;
   private boolean retryOnConnectionFailure = true;
   private static final OkHttpMultiDomainInterceptor multiDomainInterceptor =
       new OkHttpMultiDomainInterceptor();
@@ -131,8 +131,8 @@ public class DefaultHttpClientBuilder
    *
    * @return defaultHttpClientBuilder
    */
-  public DefaultHttpClientBuilder enableRetryMultiDomainOnConnectionFailure() {
-    this.retryMultiDomainOnConnectionFailure = true;
+  public DefaultHttpClientBuilder enableRetryMultiDomain() {
+    this.retryMultiDomain = true;
     return this;
   }
 
@@ -165,7 +165,7 @@ public class DefaultHttpClientBuilder
     if (proxy != null) {
       okHttpClientBuilder.proxy(proxy);
     }
-    if (retryMultiDomainOnConnectionFailure) {
+    if (retryMultiDomain) {
       okHttpClientBuilder.addInterceptor(multiDomainInterceptor);
     }
     if (!retryOnConnectionFailure) {

--- a/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
@@ -6,6 +6,7 @@ import com.wechat.pay.java.core.Config;
 import com.wechat.pay.java.core.auth.Credential;
 import com.wechat.pay.java.core.auth.Validator;
 import com.wechat.pay.java.core.http.okhttp.OkHttpClientAdapter;
+import com.wechat.pay.java.core.http.okhttp.OkHttpMultiDomainInterceptor;
 import java.net.Proxy;
 import java.util.concurrent.TimeUnit;
 
@@ -21,6 +22,9 @@ public class DefaultHttpClientBuilder
   private int writeTimeoutMs = -1;
   private int connectTimeoutMs = -1;
   private Proxy proxy;
+  private boolean disableMultiDomain = false;
+  private static final OkHttpMultiDomainInterceptor multiDomainInterceptor =
+      new OkHttpMultiDomainInterceptor();
 
   /**
    * 复制工厂，复制一个当前对象
@@ -120,6 +124,17 @@ public class DefaultHttpClientBuilder
     this.proxy = proxy;
     return this;
   }
+
+  /**
+   * 不使用双域名容灾
+   *
+   * @return defaultHttpClientBuilder
+   */
+  public DefaultHttpClientBuilder disableMultiDomain() {
+    this.disableMultiDomain = true;
+    return this;
+  }
+
   /**
    * 构建默认HttpClient
    *
@@ -142,6 +157,9 @@ public class DefaultHttpClientBuilder
     }
     if (proxy != null) {
       okHttpClientBuilder.proxy(proxy);
+    }
+    if (!disableMultiDomain) {
+      okHttpClientBuilder.addInterceptor(multiDomainInterceptor);
     }
     return new OkHttpClientAdapter(credential, validator, okHttpClientBuilder.build());
   }

--- a/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilder.java
@@ -22,7 +22,8 @@ public class DefaultHttpClientBuilder
   private int writeTimeoutMs = -1;
   private int connectTimeoutMs = -1;
   private Proxy proxy;
-  private boolean disableMultiDomain = false;
+  private boolean retryMultiDomainOnConnectionFailure = false;
+  private boolean retryOnConnectionFailure = true;
   private static final OkHttpMultiDomainInterceptor multiDomainInterceptor =
       new OkHttpMultiDomainInterceptor();
 
@@ -126,12 +127,20 @@ public class DefaultHttpClientBuilder
   }
 
   /**
-   * 不使用双域名容灾
+   * 启用双域名容灾
    *
    * @return defaultHttpClientBuilder
    */
-  public DefaultHttpClientBuilder disableMultiDomain() {
-    this.disableMultiDomain = true;
+  public DefaultHttpClientBuilder enableRetryMultiDomainOnConnectionFailure() {
+    this.retryMultiDomainOnConnectionFailure = true;
+    return this;
+  }
+
+  /**
+   * OkHttp 在网络问题时不重试
+   */
+  public DefaultHttpClientBuilder disableRetryOnConnectionFailure() {
+    this.retryOnConnectionFailure = false;
     return this;
   }
 
@@ -158,8 +167,11 @@ public class DefaultHttpClientBuilder
     if (proxy != null) {
       okHttpClientBuilder.proxy(proxy);
     }
-    if (!disableMultiDomain) {
+    if (retryMultiDomainOnConnectionFailure) {
       okHttpClientBuilder.addInterceptor(multiDomainInterceptor);
+    }
+    if (!retryOnConnectionFailure) {
+      okHttpClientBuilder.retryOnConnectionFailure(false);
     }
     return new OkHttpClientAdapter(credential, validator, okHttpClientBuilder.build());
   }

--- a/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpMultiDomainInterceptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpMultiDomainInterceptor.java
@@ -1,22 +1,18 @@
 package com.wechat.pay.java.core.http.okhttp;
 
+import com.wechat.pay.java.core.http.Constant;
 import java.io.IOException;
-
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.wechat.pay.java.core.http.Constant;
-
-import okhttp3.HttpUrl;
-import okhttp3.Interceptor;
-import okhttp3.Request;
-
 /**
- * A dual-domain retry interceptor.
- * This is an application interceptor that retries a request using "api2.wechatpay.cn" in case of network failure.
- * It leverages disaster recovery in different city access data centers,
- * while also avoiding failures due to DNS blocking.
+ * A dual-domain retry interceptor. This is an application interceptor that retries a request using
+ * "api2.wechatpay.cn" in case of network failure. It leverages disaster recovery in different city
+ * access data centers, while also avoiding failures due to DNS blocking.
  */
 public class OkHttpMultiDomainInterceptor implements Interceptor {
   private static final Logger logger = LoggerFactory.getLogger(OkHttpMultiDomainInterceptor.class);
@@ -27,7 +23,8 @@ public class OkHttpMultiDomainInterceptor implements Interceptor {
     Request request = chain.request();
     String hostname = request.url().host();
 
-    boolean shouldRetry = (hostname.equals("api.mch.weixin.qq.com") || hostname.equals("api.wechatpay.cn"));
+    boolean shouldRetry =
+        (hostname.equals("api.mch.weixin.qq.com") || hostname.equals("api.wechatpay.cn"));
 
     if (shouldRetry) {
       try {
@@ -54,7 +51,8 @@ public class OkHttpMultiDomainInterceptor implements Interceptor {
 
     Request.Builder reqBuilder = originalRequest.newBuilder();
     reqBuilder.url(urlBuilder.build());
-    reqBuilder.header(Constant.USER_AGENT, originalRequest.header(Constant.USER_AGENT) + " (Retried-V1)");
+    reqBuilder.header(
+        Constant.USER_AGENT, originalRequest.header(Constant.USER_AGENT) + " (Retried-V1)");
 
     return reqBuilder.build();
   }

--- a/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpMultiDomainInterceptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpMultiDomainInterceptor.java
@@ -21,12 +21,8 @@ public class OkHttpMultiDomainInterceptor implements Interceptor {
   @Override
   public okhttp3.Response intercept(Chain chain) throws IOException {
     Request request = chain.request();
-    String hostname = request.url().host();
 
-    boolean shouldRetry =
-        (hostname.equals("api.mch.weixin.qq.com") || hostname.equals("api.wechatpay.cn"));
-
-    if (shouldRetry) {
+    if (shouldRetry(request)) {
       try {
         /*
          * Implementations of this interface throw IOException to signal connectivity failures.
@@ -45,9 +41,13 @@ public class OkHttpMultiDomainInterceptor implements Interceptor {
     return chain.proceed(request);
   }
 
+  private boolean shouldRetry(Request request) {
+    return Constant.PRIMARY_API_DOMAIN.contains(request.url().host());
+  }
+
   private Request modifyRequestForRetry(Request originalRequest) {
     HttpUrl.Builder urlBuilder = originalRequest.url().newBuilder();
-    urlBuilder.host("api2.wechatpay.cn");
+    urlBuilder.host(Constant.SECONDARY_API_DOMAIN);
 
     Request.Builder reqBuilder = originalRequest.newBuilder();
     reqBuilder.url(urlBuilder.build());

--- a/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpMultiDomainInterceptor.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpMultiDomainInterceptor.java
@@ -1,0 +1,61 @@
+package com.wechat.pay.java.core.http.okhttp;
+
+import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.wechat.pay.java.core.http.Constant;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+
+/**
+ * A dual-domain retry interceptor.
+ * This is an application interceptor that retries a request using "api2.wechatpay.cn" in case of network failure.
+ * It leverages disaster recovery in different city access data centers,
+ * while also avoiding failures due to DNS blocking.
+ */
+public class OkHttpMultiDomainInterceptor implements Interceptor {
+  private static final Logger logger = LoggerFactory.getLogger(OkHttpMultiDomainInterceptor.class);
+
+  @NotNull
+  @Override
+  public okhttp3.Response intercept(Chain chain) throws IOException {
+    Request request = chain.request();
+    String hostname = request.url().host();
+
+    boolean shouldRetry = (hostname.equals("api.mch.weixin.qq.com") || hostname.equals("api.wechatpay.cn"));
+
+    if (shouldRetry) {
+      try {
+        /*
+         * Implementations of this interface throw IOException to signal connectivity failures.
+         * This includes both natural exceptions such as unreachable servers,
+         * as well as synthetic exceptions when responses are of an unexpected type or cannot be decoded
+         */
+        return chain.proceed(request);
+      } catch (IOException e) {
+        logger.warn("Retrying request due to connectivity failure: {}", e.getMessage(), e);
+
+        Request retryRequest = modifyRequestForRetry(request);
+        return chain.proceed(retryRequest);
+      }
+    }
+
+    return chain.proceed(request);
+  }
+
+  private Request modifyRequestForRetry(Request originalRequest) {
+    HttpUrl.Builder urlBuilder = originalRequest.url().newBuilder();
+    urlBuilder.host("api2.wechatpay.cn");
+
+    Request.Builder reqBuilder = originalRequest.newBuilder();
+    reqBuilder.url(urlBuilder.build());
+    reqBuilder.header(Constant.USER_AGENT, originalRequest.header(Constant.USER_AGENT) + " (Retried-V1)");
+
+    return reqBuilder.build();
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilderTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/DefaultHttpClientBuilderTest.java
@@ -53,6 +53,8 @@ class DefaultHttpClientBuilderTest {
             .validator(validator)
             .okHttpClient(okHttpClient)
             .proxy(new Proxy(Type.SOCKS, new InetSocketAddress("localhost", 8099)))
+            .enableRetryMultiDomain()
+            .disableRetryOnConnectionFailure()
             .build();
     assertNotNull(httpClient);
   }

--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpMultiDomainInterceptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpMultiDomainInterceptorTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class OkHttpMultiDomainInterceptorTest {
+class OkHttpMultiDomainInterceptorTest {
   private FakeDns fakeDns;
 
   @BeforeEach

--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpMultiDomainInterceptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpMultiDomainInterceptorTest.java
@@ -1,0 +1,117 @@
+package com.wechat.pay.java.core.http;
+
+import okhttp3.Dns;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import com.wechat.pay.java.core.http.okhttp.OkHttpMultiDomainInterceptor;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OkHttpMultiDomainInterceptorTest {
+  private FakeDns fakeDns;
+
+  @BeforeEach
+  void setUp() {
+    fakeDns = new FakeDns();
+  }
+
+  @Disabled("manual test")
+  @Test
+  void testOkHttpMultiDomain() throws IOException {
+    OkHttpMultiDomainInterceptor interceptor = new OkHttpMultiDomainInterceptor();
+    final OkHttpClient client = new OkHttpClient.Builder().dns(fakeDns).addInterceptor(interceptor).build();
+
+    InetAddress nullAddress = InetAddress.getByName("10.0.0.1");
+    InetAddress realAddress = InetAddress.getByName("121.51.50.140");
+    fakeDns.addAddress("api.mch.weixin.qq.com", nullAddress);
+    fakeDns.addAddress("api2.wechatpay.cn", realAddress);
+
+    Request request = new Request.Builder()
+        .url("https://api.mch.weixin.qq.com/v3/pay/transactions/id/1234?mchid=1234")
+        .header("User-Agent", "testOkHttpMultiDomain")
+        .header("Accept", "*/*")
+        .build();
+
+    try (Response response = client.newCall(request).execute()) {
+      assertEquals(401, response.code());
+    }
+  }
+
+  @Test
+  void testOkHttpMultiDomainWithMock() throws Exception {
+    MockWebServer server = new MockWebServer();
+    OkHttpMultiDomainInterceptor interceptor = new OkHttpMultiDomainInterceptor();
+    final OkHttpClient client = new OkHttpClient.Builder().dns(fakeDns).addInterceptor(interceptor).build();
+
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+    server.enqueue(new MockResponse()
+        .setBody("Successful"));
+
+    HttpUrl mockUrl = server.url("/test");
+    System.out.println(mockUrl.host());
+    fakeDns.addAddress("api.mch.weixin.qq.com",
+        InetAddress.getByAddress("api.mch.weixin.qq.com", new byte[] { 127, 0, 0, 1 }));
+    fakeDns.addAddress("api2.wechatpay.cn",
+        InetAddress.getByAddress("api2.wechatpay.cn", new byte[] { 127, 0, 0, 1 }));
+
+    Request request = new Request.Builder()
+        .url(mockUrl.newBuilder().host("api.mch.weixin.qq.com").build())
+        .header("User-Agent", "testOkHttpMultiDomain")
+        .header("Accept", "*/*")
+        .build();
+
+    try (Response response = client.newCall(request).execute()) {
+      assertEquals(200, response.code());
+
+      RecordedRequest request1 = server.takeRequest();
+      // Host: <host>:<port>
+      assertTrue(request1.getHeader("Host").contains("api.mch.weixin.qq.com"));
+
+      RecordedRequest request2 = server.takeRequest();
+      assertTrue(request2.getHeader("Host").contains("api2.wechatpay.cn"));
+      assertEquals("testOkHttpMultiDomain (Retried-V1)", request2.getHeader("User-Agent"));
+    }
+
+    server.shutdown();
+  }
+
+  private static class FakeDns implements Dns {
+    private final Map<String, List<InetAddress>> addressMappings = new HashMap<>();
+
+    void addAddress(String hostname, InetAddress address) {
+      addressMappings.computeIfAbsent(hostname, k -> new ArrayList<>()).add(address);
+    }
+
+    @NotNull
+    @Override
+    public List<InetAddress> lookup(@NotNull String hostname) throws UnknownHostException {
+      List<InetAddress> addresses = addressMappings.get(hostname);
+      if (addresses != null) {
+        return addresses;
+      } else {
+        throw new UnknownHostException("Unable to resolve the hostname: " + hostname);
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpMultiDomainInterceptorTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpMultiDomainInterceptorTest.java
@@ -1,5 +1,16 @@
 package com.wechat.pay.java.core.http;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.wechat.pay.java.core.http.okhttp.OkHttpMultiDomainInterceptor;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import okhttp3.Dns;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -14,19 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.wechat.pay.java.core.http.okhttp.OkHttpMultiDomainInterceptor;
-
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class OkHttpMultiDomainInterceptorTest {
   private FakeDns fakeDns;
 
@@ -39,18 +37,20 @@ public class OkHttpMultiDomainInterceptorTest {
   @Test
   void testOkHttpMultiDomain() throws IOException {
     OkHttpMultiDomainInterceptor interceptor = new OkHttpMultiDomainInterceptor();
-    final OkHttpClient client = new OkHttpClient.Builder().dns(fakeDns).addInterceptor(interceptor).build();
+    final OkHttpClient client =
+        new OkHttpClient.Builder().dns(fakeDns).addInterceptor(interceptor).build();
 
     InetAddress nullAddress = InetAddress.getByName("10.0.0.1");
     InetAddress realAddress = InetAddress.getByName("121.51.50.140");
     fakeDns.addAddress("api.mch.weixin.qq.com", nullAddress);
     fakeDns.addAddress("api2.wechatpay.cn", realAddress);
 
-    Request request = new Request.Builder()
-        .url("https://api.mch.weixin.qq.com/v3/pay/transactions/id/1234?mchid=1234")
-        .header("User-Agent", "testOkHttpMultiDomain")
-        .header("Accept", "*/*")
-        .build();
+    Request request =
+        new Request.Builder()
+            .url("https://api.mch.weixin.qq.com/v3/pay/transactions/id/1234?mchid=1234")
+            .header("User-Agent", "testOkHttpMultiDomain")
+            .header("Accept", "*/*")
+            .build();
 
     try (Response response = client.newCall(request).execute()) {
       assertEquals(401, response.code());
@@ -61,25 +61,27 @@ public class OkHttpMultiDomainInterceptorTest {
   void testOkHttpMultiDomainWithMock() throws Exception {
     MockWebServer server = new MockWebServer();
     OkHttpMultiDomainInterceptor interceptor = new OkHttpMultiDomainInterceptor();
-    final OkHttpClient client = new OkHttpClient.Builder().dns(fakeDns).addInterceptor(interceptor).build();
+    final OkHttpClient client =
+        new OkHttpClient.Builder().dns(fakeDns).addInterceptor(interceptor).build();
 
-    server.enqueue(new MockResponse()
-        .setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
-    server.enqueue(new MockResponse()
-        .setBody("Successful"));
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+    server.enqueue(new MockResponse().setBody("Successful"));
 
     HttpUrl mockUrl = server.url("/test");
     System.out.println(mockUrl.host());
-    fakeDns.addAddress("api.mch.weixin.qq.com",
-        InetAddress.getByAddress("api.mch.weixin.qq.com", new byte[] { 127, 0, 0, 1 }));
-    fakeDns.addAddress("api2.wechatpay.cn",
-        InetAddress.getByAddress("api2.wechatpay.cn", new byte[] { 127, 0, 0, 1 }));
+    fakeDns.addAddress(
+        "api.mch.weixin.qq.com",
+        InetAddress.getByAddress("api.mch.weixin.qq.com", new byte[] {127, 0, 0, 1}));
+    fakeDns.addAddress(
+        "api2.wechatpay.cn",
+        InetAddress.getByAddress("api2.wechatpay.cn", new byte[] {127, 0, 0, 1}));
 
-    Request request = new Request.Builder()
-        .url(mockUrl.newBuilder().host("api.mch.weixin.qq.com").build())
-        .header("User-Agent", "testOkHttpMultiDomain")
-        .header("Accept", "*/*")
-        .build();
+    Request request =
+        new Request.Builder()
+            .url(mockUrl.newBuilder().host("api.mch.weixin.qq.com").build())
+            .header("User-Agent", "testOkHttpMultiDomain")
+            .header("Accept", "*/*")
+            .build();
 
     try (Response response = client.newCall(request).execute()) {
       assertEquals(200, response.code());


### PR DESCRIPTION
根据 [跨城冗灾升级指引](https://pay.weixin.qq.com/wiki/doc/apiv3/Practices/chapter1_1_4.shtml)，在 HTTP 层实现了在网络失败时，使用 api2.wechatpay.cn 重试。

实现方案有两种：
1. 目前使用的方案，使用拦截器，`IOException` 时重试，修改请求的 hostname 至 api2.wechatpay.cn
2. 重写 `OkHttp.Dns`，域名解析返回 api 和 api2 混合的 IP 列表

综合考虑，采用第一种方案，它虽然略微复杂，测试麻烦，但易于扩展，能有效地标识重试请求，可以跟踪重试的情况。