### PR TITLE
Fix empty post and keepaliveduration

### DIFF
--- a/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
@@ -58,7 +58,8 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
     Map<String, String> headers = wechatPayRequest.getHeaders().getHeaders();
     headers.forEach(okHttpRequestBuilder::addHeader);
     String method = wechatPayRequest.getHttpMethod().name();
-    RequestBody okHttpRequestBody = buildOkHttpRequestBody(wechatPayRequest.getBody());
+    RequestBody okHttpRequestBody =
+        method.equals("GET") ? null : buildOkHttpRequestBody(wechatPayRequest.getBody());
     okHttpRequestBuilder.method(method, okHttpRequestBody);
     return okHttpRequestBuilder.build();
   }
@@ -66,7 +67,8 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
   private RequestBody buildOkHttpRequestBody(
       com.wechat.pay.java.core.http.RequestBody wechatPayRequestBody) {
     if (wechatPayRequestBody == null) {
-      return null;
+      // create an empty request body
+      return RequestBody.create("", null);
     }
     if (wechatPayRequestBody instanceof JsonRequestBody) {
       return createOkHttpRequestBody(wechatPayRequestBody);

--- a/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/HttpClientTest.java
@@ -41,8 +41,10 @@ public interface HttpClientTest {
   static Stream<Arguments> requestProvider() {
     return Stream.of(
         arguments(HttpMethod.GET, Named.of("无body", "")),
+        arguments(HttpMethod.GET, Named.of("null body", null)),
         arguments(HttpMethod.DELETE, Named.of("无body", "")),
         arguments(HttpMethod.POST, Named.of("无body", "")),
+        arguments(HttpMethod.POST, Named.of("null body", null)),
         arguments(HttpMethod.POST, Named.of("有body", "post-data")),
         arguments(HttpMethod.PUT, Named.of("无body", "")),
         arguments(HttpMethod.PUT, Named.of("有body", "put-data")),
@@ -72,7 +74,8 @@ public interface HttpClientTest {
         new HttpRequest.Builder().httpMethod(method).url(requestUrl.url()).headers(headers);
 
     if (method == HttpMethod.POST || method == HttpMethod.PATCH || method == HttpMethod.PUT) {
-      requestBuilder.body(new JsonRequestBody.Builder().body(requestBody).build());
+      requestBuilder.body(
+          requestBody == null ? null : new JsonRequestBody.Builder().body(requestBody).build());
     }
 
     client.execute(requestBuilder.build(), null);
@@ -82,7 +85,7 @@ public interface HttpClientTest {
     assertEquals(requestUrl, request.getRequestUrl());
     assertEquals("HeaderValue1", request.getHeader("Test-Header1"));
     assertEquals("HeaderValue2", request.getHeader("Test-Header2"));
-    assertEquals(requestBody, request.getBody().readUtf8());
+    assertEquals(requestBody == null ? "" : requestBody, request.getBody().readUtf8());
 
     server.shutdown();
   }
@@ -106,7 +109,8 @@ public interface HttpClientTest {
         new HttpRequest.Builder().httpMethod(method).url(requestUrl.url());
 
     if (method == HttpMethod.POST || method == HttpMethod.PATCH || method == HttpMethod.PUT) {
-      requestBuilder.body(new JsonRequestBody.Builder().body(requestBody).build());
+      requestBuilder.body(
+          requestBody == null ? null : new JsonRequestBody.Builder().body(requestBody).build());
     }
 
     HttpResponse<Response> response = client.execute(requestBuilder.build(), Response.class);
@@ -139,7 +143,8 @@ public interface HttpClientTest {
         new HttpRequest.Builder().httpMethod(method).url(requestUrl.url());
 
     if (method == HttpMethod.POST || method == HttpMethod.PATCH || method == HttpMethod.PUT) {
-      requestBuilder.body(new JsonRequestBody.Builder().body(requestBody).build());
+      requestBuilder.body(
+          requestBody == null ? null : new JsonRequestBody.Builder().body(requestBody).build());
     }
 
     assertDoesNotThrow(() -> client.execute(requestBuilder.build(), Response.class));

--- a/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/OkHttpClientAdapterTest.java
@@ -749,7 +749,7 @@ public class OkHttpClientAdapterTest {
                       executeSendDeleteHeaders.get(AUTHORIZATION));
                   Assert.assertEquals(
                       REQUEST_HEADER_VALUE, executeSendDeleteHeaders.get(REQUEST_HEADER_KEY));
-                  Assert.assertNull(chain.request().body());
+                  Assert.assertEquals(0, chain.request().body().contentLength());
 
                   return new Response.Builder()
                       .request(chain.request())
@@ -1298,7 +1298,7 @@ public class OkHttpClientAdapterTest {
                   Assert.assertEquals(
                       deleteCredential.getAuthorization(URI.create(URL), deleteMethod, ""),
                       deleteHeaders.get(AUTHORIZATION));
-                  Assert.assertNull(chain.request().body());
+                  Assert.assertEquals(0, chain.request().body().contentLength());
 
                   return new Response.Builder()
                       .request(chain.request())

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1. 修复 POST + 空 body 的失败。
2. 设置 `DefaultHttpClient` 的 keep-alive duration 为7秒，减少空闲时的重连。因为微信支付服务器 Keep-Alive 时长设置是8s。
3. 将 gradle 升级至 8.1.1