### PR TITLE
fix issues #352

### DIFF
--- a/core/src/main/java/com/wechat/pay/java/core/http/apache/ApacheHttpClientAdapter.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/apache/ApacheHttpClientAdapter.java
@@ -108,7 +108,7 @@ public class ApacheHttpClientAdapter extends AbstractHttpClient {
     if (wechatPayRequestBody instanceof JsonRequestBody) {
       return new StringEntity(
           ((JsonRequestBody) wechatPayRequestBody).getBody(),
-          ContentType.create(wechatPayRequestBody.getContentType(),"UTF-8")); 
+          ContentType.create(wechatPayRequestBody.getContentType(), StandardCharsets.UTF_8));
     }
     if (wechatPayRequestBody instanceof FileRequestBody) {
       FileRequestBody fileRequestBody = (FileRequestBody) wechatPayRequestBody;

--- a/core/src/main/java/com/wechat/pay/java/core/http/apache/ApacheHttpClientAdapter.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/apache/ApacheHttpClientAdapter.java
@@ -104,11 +104,11 @@ public class ApacheHttpClientAdapter extends AbstractHttpClient {
     if (wechatPayRequestBody == null) {
       return new StringEntity("", "");
     }
-
+    // 指定ContentType参数为UTF-8， fix issues #352
     if (wechatPayRequestBody instanceof JsonRequestBody) {
       return new StringEntity(
           ((JsonRequestBody) wechatPayRequestBody).getBody(),
-          ContentType.create(wechatPayRequestBody.getContentType()));
+          ContentType.create(wechatPayRequestBody.getContentType(),"UTF-8")); 
     }
     if (wechatPayRequestBody instanceof FileRequestBody) {
       FileRequestBody fileRequestBody = (FileRequestBody) wechatPayRequestBody;

--- a/core/src/main/java/com/wechat/pay/java/core/http/apache/ApacheHttpClientAdapter.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/apache/ApacheHttpClientAdapter.java
@@ -15,6 +15,7 @@ import com.wechat.pay.java.core.http.JsonRequestBody;
 import com.wechat.pay.java.core.http.OriginalResponse;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.http.Header;

--- a/core/src/test/java/com/wechat/pay/java/core/http/ApacheHttpClientAdapterTest.java
+++ b/core/src/test/java/com/wechat/pay/java/core/http/ApacheHttpClientAdapterTest.java
@@ -11,6 +11,7 @@ import com.wechat.pay.java.core.util.IOUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.apache.http.Header;
@@ -253,7 +254,7 @@ public class ApacheHttpClientAdapterTest {
             HttpEntity entity =
                 new StringEntity(
                     JSON_REQUEST_BODY.getBody(),
-                    ContentType.create(JSON_REQUEST_BODY.getContentType()));
+                    ContentType.create(JSON_REQUEST_BODY.getContentType(), StandardCharsets.UTF_8));
             Assert.assertEquals(
                 entity.getContentType().getValue(), reqEntity.getContentType().getValue());
             Assert.assertEquals(entity.getContentLength(), reqEntity.getContentLength());
@@ -1057,7 +1058,7 @@ public class ApacheHttpClientAdapterTest {
             HttpEntity entity =
                 new StringEntity(
                     JSON_REQUEST_BODY.getBody(),
-                    ContentType.create(JSON_REQUEST_BODY.getContentType()));
+                    ContentType.create(JSON_REQUEST_BODY.getContentType(), StandardCharsets.UTF_8));
             Assert.assertEquals(
                 entity.getContentType().getValue(), reqEntity.getContentType().getValue());
             Assert.assertEquals(entity.getContentLength(), reqEntity.getContentLength());


### PR DESCRIPTION
 使用ApacheHttpClientAdapter 发送post请求时指定ContentType参数为UTF-8，解决微信客户端接收的时候中文乱码，返回验签校验失败的问题