### PR TITLE
fix: Fix the NoSuchMethodError error that occurs when calling a post request without a request body when your project depends on OkHttp3. x

### DIFF
--- a/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
+++ b/core/src/main/java/com/wechat/pay/java/core/http/okhttp/OkHttpClientAdapter.java
@@ -68,7 +68,7 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
       com.wechat.pay.java.core.http.RequestBody wechatPayRequestBody) {
     if (wechatPayRequestBody == null) {
       // create an empty request body
-      return RequestBody.create("", null);
+      return createOkHttpEmptyRequestBody();
     }
     if (wechatPayRequestBody instanceof JsonRequestBody) {
       return createOkHttpRequestBody(wechatPayRequestBody);
@@ -93,6 +93,10 @@ public final class OkHttpClientAdapter extends AbstractHttpClient {
   @SuppressWarnings("deprecation")
   private okhttp3.RequestBody createRequestBody(byte[] content, okhttp3.MediaType mediaType) {
     return okhttp3.RequestBody.create(mediaType, content);
+  }
+
+  private RequestBody createOkHttpEmptyRequestBody() {
+    return createRequestBody("", null);
   }
 
   private RequestBody createOkHttpRequestBody(


### PR DESCRIPTION
修复：当项目使用OkHttp3.x且调用了无需请求体的POST请求时，将会抛出NoSuchMethodError异常